### PR TITLE
Fix sampleStore, remove unnecessary watcher

### DIFF
--- a/src/effector/__tests__/sample.test.js
+++ b/src/effector/__tests__/sample.test.js
@@ -73,4 +73,66 @@ describe('sample', () => {
     expect(getSpyCalls()).toEqual([[{x: 'baz'}]])
     expect(spy).toHaveBeenCalledTimes(1)
   })
+
+  test('store has the same state as source', () => {
+    const stop = createEvent()
+
+    const s1 = createStore(0)
+    s1.setState(1)
+
+    const s2 = sample(s1, stop)
+
+    expect(s2.getState()).toEqual(s1.getState())
+  })
+
+  test('store has its own defaultState', () => {
+    const stop = createEvent()
+
+    const s1 = createStore(0)
+    s1.setState(1)
+
+    const s2 = sample(s1, stop)
+
+    expect(s2.defaultState).toEqual(1)
+  })
+
+  test('store updates if source updates', () => {
+    const stop = createEvent()
+
+    const s1 = createStore(0)
+    s1.setState(1)
+
+    const s2 = sample(s1, stop)
+
+    s2.watch(value => spy(value)) // 1st call
+
+    // Source updates
+    s1.setState(2)
+    s1.setState(0) // to initial state
+
+    stop() // 2nd call
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  test('store updates only if source is changed', () => {
+    const stop = createEvent()
+
+    const s1 = createStore(0)
+    const s2 = sample(s1, stop)
+
+    s2.watch(value => spy(value)) // 1st call
+
+    stop()
+    s1.setState(0)
+    stop()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    s1.setState(1)
+    s1.setState(2)
+    stop() // 2nd call
+    stop()
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/effector/sample.js
+++ b/src/effector/sample.js
@@ -8,24 +8,15 @@ import type {Effect} from 'effector/effect'
 import invariant from 'invariant'
 
 function sampleStore(source: Store<any>, sampler: Event<any> | Store<any>) {
-  let current
-  let hasValue = false
-
   const unit = storeFabric({
-    currentState: source.defaultState,
+    currentState: source.getState(),
     //TODO: add location
     config: {name: source.shortName},
     parent: source.domainName,
   })
 
-  //TODO: unsubscribe from this
-  const unsub = source.watch(value => {
-    current = value
-    hasValue = true
-  })
-
   sampler.watch(() => {
-    if (hasValue) unit.setState(current)
+    unit.setState(source.getState())
   })
 
   return unit


### PR DESCRIPTION
Add tests:

- store has the same state as source
- store has its own defaultState
- store updates if source updates
- store updates only if source is changed

Fix:

- Remove watch and use getState

Let's discuss sampleStore intended behaviour