### PR TITLE
Nicer typings for createApi()

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -251,7 +251,11 @@ export function createApi<
   store: Store<S>,
   api: Api,
 ): {
-  [K in keyof Api]: Api[K] extends (store: S, e: infer E) => S ? Event<E> : any
+  [K in keyof Api]: Api[K] extends (store: S, e: void) => S
+    ? Event<void>
+    : Api[K] extends (store: S, e: infer E) => S
+    ? Event<E extends void ? Exclude<E, undefined> | void : E>
+    : any
 }
 
 export function extract<State, NextState>(


### PR DESCRIPTION
Closes #102 
Note: `Exclude<E, undefined>` needed to remove noise from typings: `string | undefined | void` is the same as `string | void`