### PR TITLE
Add shortName to types

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -21,8 +21,8 @@ export const Kind: {
 
 export type Observer<A> = {
   readonly next?: (value: A) => void
-  // error(err: Error): void,
-  //complete(): void,
+  //error(err: Error): void
+  //complete(): void
 }
 
 export type Observable<T> = {
@@ -40,6 +40,12 @@ export interface Unit<T> {
   readonly __: T
 }
 
+export type CompositeName = {
+  shortName: string
+  fullName: string
+  path: Array<string>
+}
+
 export interface Event<Payload> extends Unit<Payload> {
   (payload: Payload): Payload
   watch(watcher: (payload: Payload) => any): Subscription
@@ -54,6 +60,9 @@ export interface Event<Payload> extends Unit<Payload> {
   subscribe(observer: Observer<Payload>): Subscription
   thru<U>(fn: (event: Event<Payload>) => U): U
   getType(): string
+  domainName?: CompositeName
+  compositeName: CompositeName
+  shortName: string
   [Symbol.observable](): Observable<Payload>
 }
 
@@ -87,6 +96,9 @@ export interface Effect<Params, Done, Fail = Error> extends Unit<Params> {
   prepend<Before>(fn: (_: Before) => Params): Event<Before>
   subscribe(observer: Observer<Params>): Subscription
   getType(): string
+  domainName?: CompositeName
+  compositeName: CompositeName
+  shortName: string
   [Symbol.observable](): Observable<Params>
 }
 
@@ -108,8 +120,10 @@ export interface Store<State> extends Unit<State> {
     watcher: (state: State, payload: E) => any,
   ): Subscription
   thru<U>(fn: (store: Store<State>) => U): U
-  shortName: string
   defaultState: State
+  domainName?: CompositeName
+  compositeName: CompositeName
+  shortName: string
   [Symbol.observable](): Observable<State>
 }
 
@@ -257,10 +271,7 @@ export function setStoreName<State>(store: Store<State>, name: string): void
 export function createStoreObject<State>(
   defaultState: State,
 ): Store<{[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]}>
-export function split<
-  S,
-  Obj extends {[name: string]: (payload: S) => boolean},
->(
+export function split<S, Obj extends {[name: string]: (payload: S) => boolean}>(
   source: Unit<S>,
   cases: Obj,
 ): {[K in keyof Obj]: Event<S>} & {__: Event<S>}
@@ -302,10 +313,7 @@ export function restore<State extends {[key: string]: Store<any> | any}>(
 
 export function createDomain(domainName?: string): Domain
 
-export function sample<A>(
-  source: Store<A>,
-  clock?: Store<any>,
-): Store<A>
+export function sample<A>(source: Store<A>, clock?: Store<any>): Store<A>
 export function sample<A>(
   source: Store<A>,
   clock: Event<any> | Effect<any, any, any>,
@@ -327,44 +335,44 @@ export function sample<A, B, C>(
   greedy?: boolean,
 ): Event<C>
 export function sample<A, B, C>(config: {
-  source: Unit<A>,
-  clock: Unit<B>,
-  fn: (source: A, clock: B) => C,
+  source: Unit<A>
+  clock: Unit<B>
+  fn: (source: A, clock: B) => C
   target: Unit<C>
   greedy?: boolean
 }): Unit<C>
 export function sample<A>(config: {
-  source: Unit<A>,
-  clock: Unit<any>,
+  source: Unit<A>
+  clock: Unit<any>
   target: Unit<A>
   greedy?: boolean
 }): Unit<A>
 export function sample<A, B, C>(config: {
-  source: Store<A>,
-  clock: Store<B>,
-  fn(source: A, clock: B): C,
-  greedy?: boolean,
+  source: Store<A>
+  clock: Store<B>
+  fn(source: A, clock: B): C
+  greedy?: boolean
 }): Store<C>
 export function sample<A, B, C>(config: {
-  source: Unit<A>,
-  clock: Unit<B>,
-  fn(source: A, clock: B): C,
-  greedy?: boolean,
+  source: Unit<A>
+  clock: Unit<B>
+  fn(source: A, clock: B): C
+  greedy?: boolean
 }): Event<C>
 export function sample<A>(config: {
-  source: Store<A>,
-  clock?: Store<any>,
-  greedy?: boolean,
+  source: Store<A>
+  clock?: Store<any>
+  greedy?: boolean
 }): Store<A>
 export function sample<A>(config: {
-  source: Store<A>,
-  clock?: Event<any> | Effect<any, any, any>,
-  greedy?: boolean,
+  source: Store<A>
+  clock?: Event<any> | Effect<any, any, any>
+  greedy?: boolean
 }): Event<A>
 export function sample<A>(config: {
-  source: Event<A> | Effect<A, any, any>,
-  clock?: Unit<any>,
-  greedy?: boolean,
+  source: Event<A> | Effect<A, any, any>
+  clock?: Unit<any>
+  greedy?: boolean
 }): Event<A>
 
 export function combine<R>(fn: () => R): Store<R>

--- a/packages/effector/index.js.flow
+++ b/packages/effector/index.js.flow
@@ -34,6 +34,13 @@ export type Subscription = {
 export interface Unit<T> {
   +kind: kind;
 }
+
+export type CompositeName = {|
+  shortName: string,
+  fullName: string,
+  path: Array<string>,
+|}
+
 declare export class Event<Payload> implements Unit<Payload> {
   (payload: Payload): Payload;
   +kind: kind;
@@ -51,6 +58,9 @@ declare export class Event<Payload> implements Unit<Payload> {
   subscribe(observer: Observer<Payload>): Subscription;
   thru<U>(fn: (event: Event<Payload>) => U): U;
   getType(): string;
+  domainName?: CompositeName;
+  compositeName: CompositeName;
+  shortName: string;
 }
 
 declare export class Effect<Params, Done, Fail = Error>
@@ -87,6 +97,9 @@ declare export class Effect<Params, Done, Fail = Error>
   map<T>(fn: (params: Params) => T): Event<T>;
   subscribe(observer: Observer<Params>): Subscription;
   getType(): string;
+  domainName?: CompositeName;
+  compositeName: CompositeName;
+  shortName: string;
 }
 
 declare export class Store<State> implements Unit<State> {
@@ -111,8 +124,10 @@ declare export class Store<State> implements Unit<State> {
     watcher: (state: State, payload: E) => any,
   ): Subscription;
   thru<U>(fn: (store: Store<State>) => U): U;
-  shortName: string;
   defaultState: State;
+  domainName?: CompositeName;
+  compositeName: CompositeName;
+  shortName: string;
 }
 
 declare export var is: {|

--- a/src/types/__tests__/__snapshots__/run-tests.test.js.snap
+++ b/src/types/__tests__/__snapshots__/run-tests.test.js.snap
@@ -872,29 +872,29 @@ exports[`Flow: json messages 1`] = `
   
 
   src/types/types.test.js
-  395 |     const map_check1: Store<string> = computed
-  396 | 
-> 397 |     const map_check2: Store<number> = computed
+  399 |     const map_check1: Store<string> = computed
+  400 | 
+> 401 |     const map_check2: Store<number> = computed
       |                                       ^^^^^^^ 
       |  Cannot assign \`computed\` to \`map_check2\` 
       |  because string [1] is incompatible with number [2] in type argument \`State\` [3].
       |  
-  398 |   })
-  399 | 
+  402 |   })
+  403 | 
 
-  393 |     const computed = store.map(() => 'hello')
-  394 | 
-> 395 |     const map_check1: Store<string> = computed
+  397 |     const computed = store.map(() => 'hello')
+  398 | 
+> 399 |     const map_check1: Store<string> = computed
       |                             ^^^^^^ [1]
-  396 | 
-  397 |     const map_check2: Store<number> = computed
+  400 | 
+  401 |     const map_check2: Store<number> = computed
 
-  395 |     const map_check1: Store<string> = computed
-  396 | 
-> 397 |     const map_check2: Store<number> = computed
+  399 |     const map_check1: Store<string> = computed
+  400 | 
+> 401 |     const map_check2: Store<number> = computed
       |                             ^^^^^^ [2]
-  398 |   })
-  399 | 
+  402 |   })
+  403 | 
 
   packages/effector/index.js.flow
   103 | }
@@ -907,22 +907,22 @@ exports[`Flow: json messages 1`] = `
   
 
   src/types/types.test.js
-  477 |     const domain = createDomain()
-  478 |     const domain2 = createDomain('hello')
-> 479 |     const domain3 = createDomain(234)
+  481 |     const domain = createDomain()
+  482 |     const domain2 = createDomain('hello')
+> 483 |     const domain3 = createDomain(234)
       |                                  ^^ 
       |  Cannot call \`createDomain\` with \`234\` bound to \`domainName\` 
       |  because number [1] is incompatible with string [2].
       |  
-  480 |     const domain4 = createDomain({foo: true})
-  481 |   })
+  484 |     const domain4 = createDomain({foo: true})
+  485 |   })
 
-  477 |     const domain = createDomain()
-  478 |     const domain2 = createDomain('hello')
-> 479 |     const domain3 = createDomain(234)
+  481 |     const domain = createDomain()
+  482 |     const domain2 = createDomain('hello')
+> 483 |     const domain3 = createDomain(234)
       |                                  ^^^ [1]
-  480 |     const domain4 = createDomain({foo: true})
-  481 |   })
+  484 |     const domain4 = createDomain({foo: true})
+  485 |   })
 
   packages/effector/index.js.flow
   355 |   <S>(field: Store<S> | S) => Store<S>,
@@ -935,22 +935,22 @@ exports[`Flow: json messages 1`] = `
   
 
   src/types/types.test.js
-  478 |     const domain2 = createDomain('hello')
-  479 |     const domain3 = createDomain(234)
-> 480 |     const domain4 = createDomain({foo: true})
+  482 |     const domain2 = createDomain('hello')
+  483 |     const domain3 = createDomain(234)
+> 484 |     const domain4 = createDomain({foo: true})
       |                                  ^^^^^^^^^^ 
       |  Cannot call \`createDomain\` with object literal bound to \`domainName\` 
       |  because object literal [1] is incompatible with string [2].
       |  
-  481 |   })
-  482 | 
+  485 |   })
+  486 | 
 
-  478 |     const domain2 = createDomain('hello')
-  479 |     const domain3 = createDomain(234)
-> 480 |     const domain4 = createDomain({foo: true})
+  482 |     const domain2 = createDomain('hello')
+  483 |     const domain3 = createDomain(234)
+> 484 |     const domain4 = createDomain({foo: true})
       |                                  ^^^^^^^^^^^ [1]
-  481 |   })
-  482 | 
+  485 |   })
+  486 | 
 
   packages/effector/index.js.flow
   355 |   <S>(field: Store<S> | S) => Store<S>,
@@ -963,178 +963,178 @@ exports[`Flow: json messages 1`] = `
   
 
   src/types/types.test.js
-  494 |       },
-  495 |     })
-> 496 |     effect2(20)
+  498 |       },
+  499 |     })
+> 500 |     effect2(20)
       |             ^ 
       |  Cannot call \`effect2\` with \`20\` bound to \`payload\` 
       |  because number [1] is incompatible with string [2].
       |  
-  497 |     const effect3 = domain.effect('', {
-  498 |       handler: effect1,
+  501 |     const effect3 = domain.effect('', {
+  502 |       handler: effect1,
 
-  494 |       },
-  495 |     })
-> 496 |     effect2(20)
+  498 |       },
+  499 |     })
+> 500 |     effect2(20)
       |             ^^ [1]
-  497 |     const effect3 = domain.effect('', {
-  498 |       handler: effect1,
+  501 |     const effect3 = domain.effect('', {
+  502 |       handler: effect1,
 
-  490 |     const effect1: Effect<string, number, Error> = domain.effect()
-  491 |     const effect2 = domain.effect('', {
-> 492 |       handler(params: string) {
+  494 |     const effect1: Effect<string, number, Error> = domain.effect()
+  495 |     const effect2 = domain.effect('', {
+> 496 |       handler(params: string) {
       |                       ^^^^^^ [2]
-  493 |         return 256
-  494 |       },
+  497 |         return 256
+  498 |       },
 
   
 
   src/types/types.test.js
-  498 |       handler: effect1,
-  499 |     })
-> 500 |     effect3(20)
+  502 |       handler: effect1,
+  503 |     })
+> 504 |     effect3(20)
       |             ^ 
       |  Cannot call \`effect3\` with \`20\` bound to \`payload\` 
       |  because number [1] is incompatible with string [2].
       |  
-  501 |   })
-  502 | 
+  505 |   })
+  506 | 
 
-  498 |       handler: effect1,
-  499 |     })
-> 500 |     effect3(20)
+  502 |       handler: effect1,
+  503 |     })
+> 504 |     effect3(20)
       |             ^^ [1]
-  501 |   })
-  502 | 
+  505 |   })
+  506 | 
 
-  488 |   test('#effect', () => {
-  489 |     const domain = createDomain()
-> 490 |     const effect1: Effect<string, number, Error> = domain.effect()
+  492 |   test('#effect', () => {
+  493 |     const domain = createDomain()
+> 494 |     const effect1: Effect<string, number, Error> = domain.effect()
       |                           ^^^^^^ [2]
-  491 |     const effect2 = domain.effect('', {
-  492 |       handler(params: string) {
+  495 |     const effect2 = domain.effect('', {
+  496 |       handler(params: string) {
 
   
 
   src/types/types.test.js
-  584 |       ],
-  585 |     })
-> 586 |     launch(foo, '')
+  588 |       ],
+  589 |     })
+> 590 |     launch(foo, '')
       |                 ^ 
       |  Cannot call \`launch\` with empty string bound to \`payload\` 
       |  because string [1] is incompatible with number [2].
       |  
-  587 |     launch(foo, 0)
-  588 |     launch(customNode, 100)
+  591 |     launch(foo, 0)
+  592 |     launch(customNode, 100)
 
-  584 |       ],
-  585 |     })
-> 586 |     launch(foo, '')
+  588 |       ],
+  589 |     })
+> 590 |     launch(foo, '')
       |                 ^^ [1]
-  587 |     launch(foo, 0)
-  588 |     launch(customNode, 100)
+  591 |     launch(foo, 0)
+  592 |     launch(customNode, 100)
 
-  565 | 
-  566 |   test('launch', () => {
-> 567 |     const foo = createEvent<number>()
+  569 | 
+  570 |   test('launch', () => {
+> 571 |     const foo = createEvent<number>()
       |                             ^^^^^^ [2]
-  568 |     const customNode = createNode({
-  569 |       scope: {max: 100, lastValue: -1, add: 10},
+  572 |     const customNode = createNode({
+  573 |       scope: {max: 100, lastValue: -1, add: 10},
 
   
 
   src/types/types.test.js
-  616 |       (initialProps: {id: number}) => {
-  617 |         const createComponent_initialProps_check1: number = initialProps.id
-> 618 |         const createComponent_initialProps_check2: string = initialProps.id
+  620 |       (initialProps: {id: number}) => {
+  621 |         const createComponent_initialProps_check1: number = initialProps.id
+> 622 |         const createComponent_initialProps_check2: string = initialProps.id
       |                                                             ^^^^^^^^^^^^^^ 
       |  Cannot assign \`initialProps.id\` to \`createComponent_initialProps_check2\` 
       |  because number [1] is incompatible with string [2].
       |  
-  619 |         const createComponent_initialProps_check3: string =
-  620 |           initialProps.unknownProp
+  623 |         const createComponent_initialProps_check3: string =
+  624 |           initialProps.unknownProp
 
-  614 |     }>({})
-  615 |     const InitialProps = createComponent(
-> 616 |       (initialProps: {id: number}) => {
+  618 |     }>({})
+  619 |     const InitialProps = createComponent(
+> 620 |       (initialProps: {id: number}) => {
       |                           ^^^^^^ [1]
-  617 |         const createComponent_initialProps_check1: number = initialProps.id
-  618 |         const createComponent_initialProps_check2: string = initialProps.id
+  621 |         const createComponent_initialProps_check1: number = initialProps.id
+  622 |         const createComponent_initialProps_check2: string = initialProps.id
 
-  616 |       (initialProps: {id: number}) => {
-  617 |         const createComponent_initialProps_check1: number = initialProps.id
-> 618 |         const createComponent_initialProps_check2: string = initialProps.id
+  620 |       (initialProps: {id: number}) => {
+  621 |         const createComponent_initialProps_check1: number = initialProps.id
+> 622 |         const createComponent_initialProps_check2: string = initialProps.id
       |                                                    ^^^^^^ [2]
-  619 |         const createComponent_initialProps_check3: string =
-  620 |           initialProps.unknownProp
+  623 |         const createComponent_initialProps_check3: string =
+  624 |           initialProps.unknownProp
 
   
 
   src/types/types.test.js
-  618 |         const createComponent_initialProps_check2: string = initialProps.id
-  619 |         const createComponent_initialProps_check3: string =
-> 620 |           initialProps.unknownProp
+  622 |         const createComponent_initialProps_check2: string = initialProps.id
+  623 |         const createComponent_initialProps_check3: string =
+> 624 |           initialProps.unknownProp
       |                        ^^^^^^^^^^ 
       |  Cannot get \`initialProps.unknownProp\` 
       |  because property \`unknownProp\` is missing in object type [1].
       |  
-  621 |         return list.map(list => list[initialProps.id] || {text: 'Loading...'})
-  622 |       },
+  625 |         return list.map(list => list[initialProps.id] || {text: 'Loading...'})
+  626 |       },
 
-  614 |     }>({})
-  615 |     const InitialProps = createComponent(
-> 616 |       (initialProps: {id: number}) => {
+  618 |     }>({})
+  619 |     const InitialProps = createComponent(
+> 620 |       (initialProps: {id: number}) => {
       |                      ^^^^^^^^^^^^ [1]
-  617 |         const createComponent_initialProps_check1: number = initialProps.id
-  618 |         const createComponent_initialProps_check2: string = initialProps.id
+  621 |         const createComponent_initialProps_check1: number = initialProps.id
+  622 |         const createComponent_initialProps_check2: string = initialProps.id
 
   
 
   src/types/types.test.js
-  623 |       (_, state) => {
-  624 |         const createComponent_initialProps_check4: string = state.text
-> 625 |         const createComponent_initialProps_check5: number = state.text
+  627 |       (_, state) => {
+  628 |         const createComponent_initialProps_check4: string = state.text
+> 629 |         const createComponent_initialProps_check5: number = state.text
       |                                                             ^^^^^^^^^ 
       |  Cannot assign \`state.text\` to \`createComponent_initialProps_check5\` 
       |  because string [1] is incompatible with number [2].
       |  
-  626 |         return null
-  627 |       },
+  630 |         return null
+  631 |       },
 
-  610 |     const list = createStore<{
-  611 |       [key: number]: {
-> 612 |         text: string,
+  614 |     const list = createStore<{
+  615 |       [key: number]: {
+> 616 |         text: string,
       |               ^^^^^^ [1]
-  613 |       },
-  614 |     }>({})
+  617 |       },
+  618 |     }>({})
 
-  623 |       (_, state) => {
-  624 |         const createComponent_initialProps_check4: string = state.text
-> 625 |         const createComponent_initialProps_check5: number = state.text
+  627 |       (_, state) => {
+  628 |         const createComponent_initialProps_check4: string = state.text
+> 629 |         const createComponent_initialProps_check5: number = state.text
       |                                                    ^^^^^^ [2]
-  626 |         return null
-  627 |       },
+  630 |         return null
+  631 |       },
 
   
 
   src/types/types.test.js
-  630 | 
-  631 |   test('createGate', () => {
-> 632 |     const Foo = createGate<number>('foo')
+  634 | 
+  635 |   test('createGate', () => {
+> 636 |     const Foo = createGate<number>('foo')
       |                            ^^^^^ 
       |  Cannot call \`createGate\` 
       |  because number [1] is incompatible with object type [2] in type
       |  argument \`Props\`.
       |  
-  633 |     const Bar = createGate<{a: number}>('bar')
-  634 |     const Baz = createGate<number | null>('baz', null)
+  637 |     const Bar = createGate<{a: number}>('bar')
+  638 |     const Baz = createGate<number | null>('baz', null)
 
-  630 | 
-  631 |   test('createGate', () => {
-> 632 |     const Foo = createGate<number>('foo')
+  634 | 
+  635 |   test('createGate', () => {
+> 636 |     const Foo = createGate<number>('foo')
       |                            ^^^^^^ [1]
-  633 |     const Bar = createGate<{a: number}>('bar')
-  634 |     const Baz = createGate<number | null>('baz', null)
+  637 |     const Bar = createGate<{a: number}>('bar')
+  638 |     const Baz = createGate<number | null>('baz', null)
 
   packages/effector-react/index.js.flow
    57 | declare export function useGate<Props>(Gate: Gate<Props>, props?: Props): void
@@ -1147,29 +1147,29 @@ exports[`Flow: json messages 1`] = `
   
 
   src/types/types.test.js
-  636 |     const Component = () => {
-  637 |       useGate(Foo, 1)
-> 638 |       useGate(Bar, 1)
+  640 |     const Component = () => {
+  641 |       useGate(Foo, 1)
+> 642 |       useGate(Bar, 1)
       |                    ^ 
       |  Cannot call \`useGate\` with \`1\` bound to \`props\` 
       |  because number [1] is incompatible with object type [2].
       |  
-  639 |       useGate(Bar, {a: 1})
-  640 |       useGate(Bar, {})
+  643 |       useGate(Bar, {a: 1})
+  644 |       useGate(Bar, {})
 
-  636 |     const Component = () => {
-  637 |       useGate(Foo, 1)
-> 638 |       useGate(Bar, 1)
+  640 |     const Component = () => {
+  641 |       useGate(Foo, 1)
+> 642 |       useGate(Bar, 1)
       |                    ^^ [1]
-  639 |       useGate(Bar, {a: 1})
-  640 |       useGate(Bar, {})
+  643 |       useGate(Bar, {a: 1})
+  644 |       useGate(Bar, {})
 
-  631 |   test('createGate', () => {
-  632 |     const Foo = createGate<number>('foo')
-> 633 |     const Bar = createGate<{a: number}>('bar')
+  635 |   test('createGate', () => {
+  636 |     const Foo = createGate<number>('foo')
+> 637 |     const Bar = createGate<{a: number}>('bar')
       |                            ^^^^^^^^^^^ [2]
-  634 |     const Baz = createGate<number | null>('baz', null)
-  635 | 
+  638 |     const Baz = createGate<number | null>('baz', null)
+  639 | 
 
   "
 `;
@@ -1222,19 +1222,19 @@ types.test.ts(335,13): Type 'Event<number>' is not assignable to type 'Event<str
   Type 'number' is not assignable to type 'string'.
 types.test.ts(341,13): Type 'Event<void>' is not assignable to type 'Event<string>'.
   Type 'void' is not assignable to type 'string'.
-types.test.ts(397,11): Type 'Store<string>' is not assignable to type 'Store<number>'.
+types.test.ts(401,11): Type 'Store<string>' is not assignable to type 'Store<number>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(479,34): Argument of type '234' is not assignable to parameter of type 'string | undefined'.
-types.test.ts(480,34): Argument of type '{ foo: boolean; }' is not assignable to parameter of type 'string'.
-types.test.ts(496,13): Argument of type '20' is not assignable to parameter of type 'string'.
+types.test.ts(483,34): Argument of type '234' is not assignable to parameter of type 'string | undefined'.
+types.test.ts(484,34): Argument of type '{ foo: boolean; }' is not assignable to parameter of type 'string'.
 types.test.ts(500,13): Argument of type '20' is not assignable to parameter of type 'string'.
-types.test.ts(586,17): Argument of type '\\"\\"' is not assignable to parameter of type 'number'.
-types.test.ts(618,15): Type 'number' is not assignable to type 'string'.
-types.test.ts(620,24): Property 'unknownProp' does not exist on type '{ id: number; }'.
-types.test.ts(625,15): Type 'string' is not assignable to type 'number'.
-types.test.ts(632,28): Type 'number' does not satisfy the constraint 'object'.
-types.test.ts(638,20): Argument of type '1' is not assignable to parameter of type '{ a: number; } | undefined'.
-types.test.ts(640,20): Argument of type '{}' is not assignable to parameter of type '{ a: number; }'.
+types.test.ts(504,13): Argument of type '20' is not assignable to parameter of type 'string'.
+types.test.ts(590,17): Argument of type '\\"\\"' is not assignable to parameter of type 'number'.
+types.test.ts(622,15): Type 'number' is not assignable to type 'string'.
+types.test.ts(624,24): Property 'unknownProp' does not exist on type '{ id: number; }'.
+types.test.ts(629,15): Type 'string' is not assignable to type 'number'.
+types.test.ts(636,28): Type 'number' does not satisfy the constraint 'object'.
+types.test.ts(642,20): Argument of type '1' is not assignable to parameter of type '{ a: number; } | undefined'.
+types.test.ts(644,20): Argument of type '{}' is not assignable to parameter of type '{ a: number; }'.
   Property 'a' is missing in type '{}' but required in type '{ a: number; }'.
 useStoreMap.test.tsx(50,28): Tuple type 'readonly [number]' of length '1' has no element at index '1'.
 useStoreMap.test.tsx(71,11): Type '[number, \\"username\\" | \\"email\\" | \\"bio\\"]' is not assignable to type '[number, number]'.

--- a/src/types/__tests__/__snapshots__/run-tests.test.js.snap
+++ b/src/types/__tests__/__snapshots__/run-tests.test.js.snap
@@ -2,1139 +2,1139 @@
 
 exports[`Flow: json messages 1`] = `
 "  src/types/types.test.js
-   56 |             oneElement: list => list.length === 1,
-   57 |           })
->  58 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
+   57 |             oneElement: list => list.length === 1,
+   58 |           })
+>  59 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
       |                                                                       ^^^^^^^^ 
       |  Cannot assign \`emptyList\` to \`split_result__nofpos__user_defined_1\` 
       |  because array type [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-   59 |           const split_result__nofpos__user_defined_2: null = oneElement
-   60 |         }
+   60 |           const split_result__nofpos__user_defined_2: null = oneElement
+   61 |         }
 
-   51 |       test('split result no false-positive', () => {
-   52 |         {
->  53 |           const source: Event<string[]> = createEvent()
+   52 |       test('split result no false-positive', () => {
+   53 |         {
+>  54 |           const source: Event<string[]> = createEvent()
       |                               ^^^^^^^^ [1]
-   54 |           const {emptyList, oneElement} = split(source, {
-   55 |             emptyList: list => list.length === 0,
+   55 |           const {emptyList, oneElement} = split(source, {
+   56 |             emptyList: list => list.length === 0,
 
-   56 |             oneElement: list => list.length === 1,
-   57 |           })
->  58 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
+   57 |             oneElement: list => list.length === 1,
+   58 |           })
+>  59 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
       |                                                             ^^^^^^ [2]
-   59 |           const split_result__nofpos__user_defined_2: null = oneElement
-   60 |         }
+   60 |           const split_result__nofpos__user_defined_2: null = oneElement
+   61 |         }
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-   57 |           })
-   58 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
->  59 |           const split_result__nofpos__user_defined_2: null = oneElement
+   58 |           })
+   59 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
+>  60 |           const split_result__nofpos__user_defined_2: null = oneElement
       |                                                              ^^^^^^^^^ 
       |  Cannot assign \`oneElement\` to \`split_result__nofpos__user_defined_2\` 
       |  because \`Event\` [1] is incompatible with null [2].
       |  
-   60 |         }
-   61 |         {
+   61 |         }
+   62 |         {
 
   packages/effector/index.js.flow
-  306 | ): $ObjMap<
-  307 |   {...Obj, __: (payload: S) => boolean},
-> 308 |   (h: (payload: S) => boolean) => Event<S>,
+  321 | ): $ObjMap<
+  322 |   {...Obj, __: (payload: S) => boolean},
+> 323 |   (h: (payload: S) => boolean) => Event<S>,
       |                                   ^^^^^^^^ [1]
-  309 | >
-  310 | declare export function restoreObject<
+  324 | >
+  325 | declare export function restoreObject<
 
   src/types/types.test.js
-   57 |           })
-   58 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
->  59 |           const split_result__nofpos__user_defined_2: null = oneElement
+   58 |           })
+   59 |           const split_result__nofpos__user_defined_1: Event<number> = emptyList
+>  60 |           const split_result__nofpos__user_defined_2: null = oneElement
       |                                                       ^^^^ [2]
-   60 |         }
-   61 |         {
+   61 |         }
+   62 |         {
 
   
 
   src/types/types.test.js
-   65 |             oneElement: list => list.length === 1,
-   66 |           })
->  67 |           const split_result__nofpos__defaults_1: Event<number> = __
+   66 |             oneElement: list => list.length === 1,
+   67 |           })
+>  68 |           const split_result__nofpos__defaults_1: Event<number> = __
       |                                                                   ^ 
       |  Cannot assign \`__\` to \`split_result__nofpos__defaults_1\` 
       |  because array type [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-   68 |         }
-   69 |         {
+   69 |         }
+   70 |         {
 
-   60 |         }
-   61 |         {
->  62 |           const source: Event<string[]> = createEvent()
+   61 |         }
+   62 |         {
+>  63 |           const source: Event<string[]> = createEvent()
       |                               ^^^^^^^^ [1]
-   63 |           const {__} = split(source, {
-   64 |             emptyList: list => list.length === 0,
+   64 |           const {__} = split(source, {
+   65 |             emptyList: list => list.length === 0,
 
-   65 |             oneElement: list => list.length === 1,
-   66 |           })
->  67 |           const split_result__nofpos__defaults_1: Event<number> = __
+   66 |             oneElement: list => list.length === 1,
+   67 |           })
+>  68 |           const split_result__nofpos__defaults_1: Event<number> = __
       |                                                         ^^^^^^ [2]
-   68 |         }
-   69 |         {
+   69 |         }
+   70 |         {
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-   73 |             oneElement: list => list.length === 1,
-   74 |           })
->  75 |           const split_result__nofpos__defaults_2: null = __
+   74 |             oneElement: list => list.length === 1,
+   75 |           })
+>  76 |           const split_result__nofpos__defaults_2: null = __
       |                                                          ^ 
       |  Cannot assign \`__\` to \`split_result__nofpos__defaults_2\` 
       |  because \`Event\` [1] is incompatible with null [2].
       |  
-   76 |         }
-   77 |       })
+   77 |         }
+   78 |       })
 
   packages/effector/index.js.flow
-  306 | ): $ObjMap<
-  307 |   {...Obj, __: (payload: S) => boolean},
-> 308 |   (h: (payload: S) => boolean) => Event<S>,
+  321 | ): $ObjMap<
+  322 |   {...Obj, __: (payload: S) => boolean},
+> 323 |   (h: (payload: S) => boolean) => Event<S>,
       |                                   ^^^^^^^^ [1]
-  309 | >
-  310 | declare export function restoreObject<
+  324 | >
+  325 | declare export function restoreObject<
 
   src/types/types.test.js
-   73 |             oneElement: list => list.length === 1,
-   74 |           })
->  75 |           const split_result__nofpos__defaults_2: null = __
+   74 |             oneElement: list => list.length === 1,
+   75 |           })
+>  76 |           const split_result__nofpos__defaults_2: null = __
       |                                                   ^^^^ [2]
-   76 |         }
-   77 |       })
+   77 |         }
+   78 |       })
 
   
 
   src/types/types.test.js
-   81 |       const source: Event<string[]> = createEvent()
-   82 |       split(source, {
->  83 |         wrongResult: list => null,
+   82 |       const source: Event<string[]> = createEvent()
+   83 |       split(source, {
+>  84 |         wrongResult: list => null,
       |                              ^^^ 
       |  Cannot call \`split\` with object literal bound to \`cases\` 
       |  because null [1] is incompatible with boolean [2] in the return value of
       |  property \`wrongResult\`.
       |  
-   84 |         wrongArg_1: (list: null) => true,
-   85 |         wrongArg_2: (list: number[]) => true,
+   85 |         wrongArg_1: (list: null) => true,
+   86 |         wrongArg_2: (list: number[]) => true,
 
-   81 |       const source: Event<string[]> = createEvent()
-   82 |       split(source, {
->  83 |         wrongResult: list => null,
+   82 |       const source: Event<string[]> = createEvent()
+   83 |       split(source, {
+>  84 |         wrongResult: list => null,
       |                              ^^^^ [1]
-   84 |         wrongArg_1: (list: null) => true,
-   85 |         wrongArg_2: (list: number[]) => true,
+   85 |         wrongArg_1: (list: null) => true,
+   86 |         wrongArg_2: (list: number[]) => true,
 
   packages/effector/index.js.flow
-  298 |   S,
-  299 |   Obj: {
-> 300 |     +[name: string]: (payload: S) => boolean,
+  313 |   S,
+  314 |   Obj: {
+> 315 |     +[name: string]: (payload: S) => boolean,
       |                                      ^^^^^^^ [2]
-  301 |     ...,
-  302 |   },
+  316 |     ...,
+  317 |   },
 
   
 
   src/types/types.test.js
-   82 |       split(source, {
-   83 |         wrongResult: list => null,
->  84 |         wrongArg_1: (list: null) => true,
+   83 |       split(source, {
+   84 |         wrongResult: list => null,
+>  85 |         wrongArg_1: (list: null) => true,
       |                            ^^^ 
       |  Cannot call \`split\` with object literal bound to \`cases\` 
       |  because null [1] is incompatible with array type [2] in the first argument of
       |  property \`wrongArg_1\`.
       |  
-   85 |         wrongArg_2: (list: number[]) => true,
-   86 |       })
+   86 |         wrongArg_2: (list: number[]) => true,
+   87 |       })
 
-   82 |       split(source, {
-   83 |         wrongResult: list => null,
->  84 |         wrongArg_1: (list: null) => true,
+   83 |       split(source, {
+   84 |         wrongResult: list => null,
+>  85 |         wrongArg_1: (list: null) => true,
       |                            ^^^^ [1]
-   85 |         wrongArg_2: (list: number[]) => true,
-   86 |       })
+   86 |         wrongArg_2: (list: number[]) => true,
+   87 |       })
 
-   79 | 
-   80 |     test('split arguments no false-positive', () => {
->  81 |       const source: Event<string[]> = createEvent()
+   80 | 
+   81 |     test('split arguments no false-positive', () => {
+>  82 |       const source: Event<string[]> = createEvent()
       |                           ^^^^^^^^ [2]
-   82 |       split(source, {
-   83 |         wrongResult: list => null,
+   83 |       split(source, {
+   84 |         wrongResult: list => null,
 
   
 
   src/types/types.test.js
-   83 |         wrongResult: list => null,
-   84 |         wrongArg_1: (list: null) => true,
->  85 |         wrongArg_2: (list: number[]) => true,
+   84 |         wrongResult: list => null,
+   85 |         wrongArg_1: (list: null) => true,
+>  86 |         wrongArg_2: (list: number[]) => true,
       |                            ^^^^^ 
       |  Cannot call \`split\` with object literal bound to \`cases\` 
       |  because number [1] is incompatible with string [2] in array element of the
       |  first argument of property \`wrongArg_2\`.
       |  
-   86 |       })
-   87 |     })
+   87 |       })
+   88 |     })
 
-   83 |         wrongResult: list => null,
-   84 |         wrongArg_1: (list: null) => true,
->  85 |         wrongArg_2: (list: number[]) => true,
+   84 |         wrongResult: list => null,
+   85 |         wrongArg_1: (list: null) => true,
+>  86 |         wrongArg_2: (list: number[]) => true,
       |                            ^^^^^^ [1]
-   86 |       })
-   87 |     })
+   87 |       })
+   88 |     })
 
-   79 | 
-   80 |     test('split arguments no false-positive', () => {
->  81 |       const source: Event<string[]> = createEvent()
+   80 | 
+   81 |     test('split arguments no false-positive', () => {
+>  82 |       const source: Event<string[]> = createEvent()
       |                           ^^^^^^ [2]
-   82 |       split(source, {
-   83 |         wrongResult: list => null,
+   83 |       split(source, {
+   84 |         wrongResult: list => null,
 
   
 
   src/types/types.test.js
-   94 | 
-   95 |       const sample_ee_check1: Event<number> = c
->  96 |       const sample_ee_check2: Event<string> = c
+   95 | 
+   96 |       const sample_ee_check1: Event<number> = c
+>  97 |       const sample_ee_check2: Event<string> = c
       |                                               ^ 
       |  Cannot assign \`c\` to \`sample_ee_check2\` 
       |  because number [1] is incompatible with string [2] in type argument
       |  \`Payload\` [3].
       |  
-   97 |     })
-   98 |     test('event by event with handler', () => {
+   98 |     })
+   99 |     test('event by event with handler', () => {
 
-   89 |   describe('sample', () => {
-   90 |     test('event by event', () => {
->  91 |       const a = createEvent<number>()
+   90 |   describe('sample', () => {
+   91 |     test('event by event', () => {
+>  92 |       const a = createEvent<number>()
       |                             ^^^^^^ [1]
-   92 |       const b = createEvent<boolean>()
-   93 |       const c = sample(a, b)
+   93 |       const b = createEvent<boolean>()
+   94 |       const c = sample(a, b)
 
-   94 | 
-   95 |       const sample_ee_check1: Event<number> = c
->  96 |       const sample_ee_check2: Event<string> = c
+   95 | 
+   96 |       const sample_ee_check1: Event<number> = c
+>  97 |       const sample_ee_check2: Event<string> = c
       |                                     ^^^^^^ [2]
-   97 |     })
-   98 |     test('event by event with handler', () => {
+   98 |     })
+   99 |     test('event by event with handler', () => {
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  102 | 
-  103 |       const sample_eeh_check1: Event<{a: string, b: boolean}> = c
-> 104 |       const sample_eeh_check2: Event<string> = c
+  103 | 
+  104 |       const sample_eeh_check1: Event<{a: string, b: boolean}> = c
+> 105 |       const sample_eeh_check2: Event<string> = c
       |                                                ^ 
       |  Cannot assign \`c\` to \`sample_eeh_check2\` 
       |  because object type [1] is incompatible with string [2] in type argument
       |  \`Payload\` [3].
       |  
-  105 |     })
-  106 | 
+  106 |     })
+  107 | 
 
-  101 |       const c = sample(a, b, (a, b) => ({a, b}))
-  102 | 
-> 103 |       const sample_eeh_check1: Event<{a: string, b: boolean}> = c
+  102 |       const c = sample(a, b, (a, b) => ({a, b}))
+  103 | 
+> 104 |       const sample_eeh_check1: Event<{a: string, b: boolean}> = c
       |                                      ^^^^^^^^^^^^^^^^^^^^^^^ [1]
-  104 |       const sample_eeh_check2: Event<string> = c
-  105 |     })
+  105 |       const sample_eeh_check2: Event<string> = c
+  106 |     })
 
-  102 | 
-  103 |       const sample_eeh_check1: Event<{a: string, b: boolean}> = c
-> 104 |       const sample_eeh_check2: Event<string> = c
+  103 | 
+  104 |       const sample_eeh_check1: Event<{a: string, b: boolean}> = c
+> 105 |       const sample_eeh_check2: Event<string> = c
       |                                      ^^^^^^ [2]
-  105 |     })
-  106 | 
+  106 |     })
+  107 | 
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  111 | 
-  112 |       const sample_se_check1: Event<number> = e
-> 113 |       const sample_se_check2: Event<string> = e
+  112 | 
+  113 |       const sample_se_check1: Event<number> = e
+> 114 |       const sample_se_check2: Event<string> = e
       |                                               ^ 
       |  Cannot assign \`e\` to \`sample_se_check2\` 
       |  because number [1] is incompatible with string [2] in type argument
       |  \`Payload\` [3].
       |  
-  114 |     })
-  115 |     test('store by event with handler', () => {
+  115 |     })
+  116 |     test('store by event with handler', () => {
 
-  110 |       const e = sample(d, b)
-  111 | 
-> 112 |       const sample_se_check1: Event<number> = e
+  111 |       const e = sample(d, b)
+  112 | 
+> 113 |       const sample_se_check1: Event<number> = e
       |                                     ^^^^^^ [1]
-  113 |       const sample_se_check2: Event<string> = e
-  114 |     })
+  114 |       const sample_se_check2: Event<string> = e
+  115 |     })
 
-  111 | 
-  112 |       const sample_se_check1: Event<number> = e
-> 113 |       const sample_se_check2: Event<string> = e
+  112 | 
+  113 |       const sample_se_check1: Event<number> = e
+> 114 |       const sample_se_check2: Event<string> = e
       |                                     ^^^^^^ [2]
-  114 |     })
-  115 |     test('store by event with handler', () => {
+  115 |     })
+  116 |     test('store by event with handler', () => {
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  119 | 
-  120 |       const sample_seh_check1: Event<{a: string, b: boolean}> = e
-> 121 |       const sample_seh_check2: Event<string> = e
+  120 | 
+  121 |       const sample_seh_check1: Event<{a: string, b: boolean}> = e
+> 122 |       const sample_seh_check2: Event<string> = e
       |                                                ^ 
       |  Cannot assign \`e\` to \`sample_seh_check2\` 
       |  because object type [1] is incompatible with string [2] in type argument
       |  \`Payload\` [3].
       |  
-  122 |     })
-  123 | 
+  123 |     })
+  124 | 
 
-  118 |       const e = sample(d, b, (a, b) => ({a, b}))
-  119 | 
-> 120 |       const sample_seh_check1: Event<{a: string, b: boolean}> = e
+  119 |       const e = sample(d, b, (a, b) => ({a, b}))
+  120 | 
+> 121 |       const sample_seh_check1: Event<{a: string, b: boolean}> = e
       |                                      ^^^^^^^^^^^^^^^^^^^^^^^ [1]
-  121 |       const sample_seh_check2: Event<string> = e
-  122 |     })
+  122 |       const sample_seh_check2: Event<string> = e
+  123 |     })
 
-  119 | 
-  120 |       const sample_seh_check1: Event<{a: string, b: boolean}> = e
-> 121 |       const sample_seh_check2: Event<string> = e
+  120 | 
+  121 |       const sample_seh_check1: Event<{a: string, b: boolean}> = e
+> 122 |       const sample_seh_check2: Event<string> = e
       |                                      ^^^^^^ [2]
-  122 |     })
-  123 | 
+  123 |     })
+  124 | 
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  128 | 
-  129 |       const sample_efe_check1: Event<string> = g
-> 130 |       const sample_efe_check2: Event<number> = g
+  129 | 
+  130 |       const sample_efe_check1: Event<string> = g
+> 131 |       const sample_efe_check2: Event<number> = g
       |                                                ^ 
       |  Cannot assign \`g\` to \`sample_efe_check2\` 
       |  because string [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  131 |     })
-  132 |     test('effect by event with handler', () => {
+  132 |     })
+  133 |     test('effect by event with handler', () => {
 
-  123 | 
-  124 |     test('effect by event', () => {
-> 125 |       const f = createEffect<string, any, any>()
+  124 | 
+  125 |     test('effect by event', () => {
+> 126 |       const f = createEffect<string, any, any>()
       |                              ^^^^^^ [1]
-  126 |       const b = createEvent<boolean>()
-  127 |       const g = sample(f, b)
+  127 |       const b = createEvent<boolean>()
+  128 |       const g = sample(f, b)
 
-  128 | 
-  129 |       const sample_efe_check1: Event<string> = g
-> 130 |       const sample_efe_check2: Event<number> = g
+  129 | 
+  130 |       const sample_efe_check1: Event<string> = g
+> 131 |       const sample_efe_check2: Event<number> = g
       |                                      ^^^^^^ [2]
-  131 |     })
-  132 |     test('effect by event with handler', () => {
+  132 |     })
+  133 |     test('effect by event with handler', () => {
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  136 | 
-  137 |       const sample_efeh_check1: Event<{a: string, b: boolean}> = g
-> 138 |       const sample_efeh_check2: Event<number> = g
+  137 | 
+  138 |       const sample_efeh_check1: Event<{a: string, b: boolean}> = g
+> 139 |       const sample_efeh_check2: Event<number> = g
       |                                                 ^ 
       |  Cannot assign \`g\` to \`sample_efeh_check2\` 
       |  because object type [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  139 |     })
-  140 | 
+  140 |     })
+  141 | 
 
-  135 |       const g = sample(f, b, (a, b) => ({a, b}))
-  136 | 
-> 137 |       const sample_efeh_check1: Event<{a: string, b: boolean}> = g
+  136 |       const g = sample(f, b, (a, b) => ({a, b}))
+  137 | 
+> 138 |       const sample_efeh_check1: Event<{a: string, b: boolean}> = g
       |                                       ^^^^^^^^^^^^^^^^^^^^^^^ [1]
-  138 |       const sample_efeh_check2: Event<number> = g
-  139 |     })
+  139 |       const sample_efeh_check2: Event<number> = g
+  140 |     })
 
-  136 | 
-  137 |       const sample_efeh_check1: Event<{a: string, b: boolean}> = g
-> 138 |       const sample_efeh_check2: Event<number> = g
+  137 | 
+  138 |       const sample_efeh_check1: Event<{a: string, b: boolean}> = g
+> 139 |       const sample_efeh_check2: Event<number> = g
       |                                       ^^^^^^ [2]
-  139 |     })
-  140 | 
+  140 |     })
+  141 | 
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  145 | 
-  146 |       const sample_ss_check1: Store<boolean> = c
-> 147 |       const sample_ss_check2: Store<string> = c
+  146 | 
+  147 |       const sample_ss_check1: Store<boolean> = c
+> 148 |       const sample_ss_check2: Store<string> = c
       |                                               ^ 
       |  Cannot assign \`c\` to \`sample_ss_check2\` 
       |  because boolean [1] is incompatible with string [2] in type
       |  argument \`State\` [3].
       |  
-  148 |     })
-  149 |     test('store by store with handler', () => {
+  149 |     })
+  150 |     test('store by store with handler', () => {
 
-  144 |       const c = sample(a, b)
-  145 | 
-> 146 |       const sample_ss_check1: Store<boolean> = c
+  145 |       const c = sample(a, b)
+  146 | 
+> 147 |       const sample_ss_check1: Store<boolean> = c
       |                                     ^^^^^^^ [1]
-  147 |       const sample_ss_check2: Store<string> = c
-  148 |     })
+  148 |       const sample_ss_check2: Store<string> = c
+  149 |     })
 
-  145 | 
-  146 |       const sample_ss_check1: Store<boolean> = c
-> 147 |       const sample_ss_check2: Store<string> = c
+  146 | 
+  147 |       const sample_ss_check1: Store<boolean> = c
+> 148 |       const sample_ss_check2: Store<string> = c
       |                                     ^^^^^^ [2]
-  148 |     })
-  149 |     test('store by store with handler', () => {
+  149 |     })
+  150 |     test('store by store with handler', () => {
 
   packages/effector/index.js.flow
-   90 | }
-   91 | 
->  92 | declare export class Store<State> implements Unit<State> {
+  103 | }
+  104 | 
+> 105 | declare export class Store<State> implements Unit<State> {
       |                            ^^^^^ [3]
-   93 |   +kind: kind;
-   94 |   reset(...triggers: Array<Unit<any>>): this;
+  106 |   +kind: kind;
+  107 |   reset(...triggers: Array<Unit<any>>): this;
 
   
 
   src/types/types.test.js
-  153 | 
-  154 |       const sample_ssh_check1: Store<{a: string, b: boolean}> = c
-> 155 |       const sample_ssh_check2: Store<string> = c
+  154 | 
+  155 |       const sample_ssh_check1: Store<{a: string, b: boolean}> = c
+> 156 |       const sample_ssh_check2: Store<string> = c
       |                                                ^ 
       |  Cannot assign \`c\` to \`sample_ssh_check2\` 
       |  because object type [1] is incompatible with string [2] in type
       |  argument \`State\` [3].
       |  
-  156 |     })
-  157 |     describe('sample(Store<T>):Store<T>', () => {
+  157 |     })
+  158 |     describe('sample(Store<T>):Store<T>', () => {
 
-  152 |       const c = sample(a, b, (a, b) => ({a, b}))
-  153 | 
-> 154 |       const sample_ssh_check1: Store<{a: string, b: boolean}> = c
+  153 |       const c = sample(a, b, (a, b) => ({a, b}))
+  154 | 
+> 155 |       const sample_ssh_check1: Store<{a: string, b: boolean}> = c
       |                                      ^^^^^^^^^^^^^^^^^^^^^^^ [1]
-  155 |       const sample_ssh_check2: Store<string> = c
-  156 |     })
+  156 |       const sample_ssh_check2: Store<string> = c
+  157 |     })
 
-  153 | 
-  154 |       const sample_ssh_check1: Store<{a: string, b: boolean}> = c
-> 155 |       const sample_ssh_check2: Store<string> = c
+  154 | 
+  155 |       const sample_ssh_check1: Store<{a: string, b: boolean}> = c
+> 156 |       const sample_ssh_check2: Store<string> = c
       |                                      ^^^^^^ [2]
-  156 |     })
-  157 |     describe('sample(Store<T>):Store<T>', () => {
+  157 |     })
+  158 |     describe('sample(Store<T>):Store<T>', () => {
 
   packages/effector/index.js.flow
-   90 | }
-   91 | 
->  92 | declare export class Store<State> implements Unit<State> {
+  103 | }
+  104 | 
+> 105 | declare export class Store<State> implements Unit<State> {
       |                            ^^^^^ [3]
-   93 |   +kind: kind;
-   94 |   reset(...triggers: Array<Unit<any>>): this;
+  106 |   +kind: kind;
+  107 |   reset(...triggers: Array<Unit<any>>): this;
 
   
 
   src/types/types.test.js
-  162 |       test('incorrect case', () => {
-  163 |         const a = createStore('')
-> 164 |         const sample_s_incorrect: Store<number> = sample(a)
+  163 |       test('incorrect case', () => {
+  164 |         const a = createStore('')
+> 165 |         const sample_s_incorrect: Store<number> = sample(a)
       |                                                   ^^^^^^^^ 
       |  Cannot assign \`sample(...)\` to \`sample_s_incorrect\` 
       |  because string [1] is incompatible with number [2] in type argument \`State\` [3].
       |  
-  165 |       })
-  166 |       describe('edge case', () => {
+  166 |       })
+  167 |       describe('edge case', () => {
 
-  161 |       })
-  162 |       test('incorrect case', () => {
-> 163 |         const a = createStore('')
+  162 |       })
+  163 |       test('incorrect case', () => {
+> 164 |         const a = createStore('')
       |                               ^^ [1]
-  164 |         const sample_s_incorrect: Store<number> = sample(a)
-  165 |       })
+  165 |         const sample_s_incorrect: Store<number> = sample(a)
+  166 |       })
 
-  162 |       test('incorrect case', () => {
-  163 |         const a = createStore('')
-> 164 |         const sample_s_incorrect: Store<number> = sample(a)
+  163 |       test('incorrect case', () => {
+  164 |         const a = createStore('')
+> 165 |         const sample_s_incorrect: Store<number> = sample(a)
       |                                         ^^^^^^ [2]
-  165 |       })
-  166 |       describe('edge case', () => {
+  166 |       })
+  167 |       describe('edge case', () => {
 
   packages/effector/index.js.flow
-   90 | }
-   91 | 
->  92 | declare export class Store<State> implements Unit<State> {
+  103 | }
+  104 | 
+> 105 | declare export class Store<State> implements Unit<State> {
       |                            ^^^^^ [3]
-   93 |   +kind: kind;
-   94 |   reset(...triggers: Array<Unit<any>>): this;
+  106 |   +kind: kind;
+  107 |   reset(...triggers: Array<Unit<any>>): this;
 
   
 
   src/types/types.test.js
-  173 |           const a = createStore('')
-  174 |           const clock = createEvent()
-> 175 |           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
+  174 |           const a = createStore('')
+  175 |           const clock = createEvent()
+> 176 |           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
       |                                                          ^^^^^^^^^^^^^^^ 
       |  Cannot assign \`sample(...)\` to \`sample_s_edge_incorrect\` 
       |  because string [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  176 |         })
-  177 |       })
+  177 |         })
+  178 |       })
 
-  171 |         })
-  172 |         test('incorrect case', () => {
-> 173 |           const a = createStore('')
+  172 |         })
+  173 |         test('incorrect case', () => {
+> 174 |           const a = createStore('')
       |                                 ^^ [1]
-  174 |           const clock = createEvent()
-  175 |           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
+  175 |           const clock = createEvent()
+  176 |           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
 
-  173 |           const a = createStore('')
-  174 |           const clock = createEvent()
-> 175 |           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
+  174 |           const a = createStore('')
+  175 |           const clock = createEvent()
+> 176 |           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
       |                                                ^^^^^^ [2]
-  176 |         })
-  177 |       })
+  177 |         })
+  178 |       })
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  193 | 
-  194 |     //const check1: Event<string> = computed
-> 195 |     const event_map_check2: Event<number> = computed
+  207 | 
+  208 |     //const check1: Event<string> = computed
+> 209 |     const event_map_check2: Event<number> = computed
       |                                             ^^^^^^^ 
       |  Cannot assign \`computed\` to \`event_map_check2\` 
       |  because string [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  196 |     event(2)
-  197 |     computed('')
+  210 |     event(2)
+  211 |     computed('')
 
-  190 |   test('#map', () => {
-  191 |     const event: Event<number> = createEvent()
-> 192 |     const computed = event.map(() => 'foo')
+  204 |   test('#map', () => {
+  205 |     const event: Event<number> = createEvent()
+> 206 |     const computed = event.map(() => 'foo')
       |                                      ^^^^^ [1]
-  193 | 
-  194 |     //const check1: Event<string> = computed
+  207 | 
+  208 |     //const check1: Event<string> = computed
 
-  193 | 
-  194 |     //const check1: Event<string> = computed
-> 195 |     const event_map_check2: Event<number> = computed
+  207 | 
+  208 |     //const check1: Event<string> = computed
+> 209 |     const event_map_check2: Event<number> = computed
       |                                   ^^^^^^ [2]
-  196 |     event(2)
-  197 |     computed('')
+  210 |     event(2)
+  211 |     computed('')
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  193 | 
-  194 |     //const check1: Event<string> = computed
-> 195 |     const event_map_check2: Event<number> = computed
+  207 | 
+  208 |     //const check1: Event<string> = computed
+> 209 |     const event_map_check2: Event<number> = computed
       |                                             ^^^^^^^ 
       |  Cannot assign \`computed\` to \`event_map_check2\` 
       |  because string [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  196 |     event(2)
-  197 |     computed('')
+  210 |     event(2)
+  211 |     computed('')
 
-  195 |     const event_map_check2: Event<number> = computed
-  196 |     event(2)
-> 197 |     computed('')
+  209 |     const event_map_check2: Event<number> = computed
+  210 |     event(2)
+> 211 |     computed('')
       |              ^^ [1]
-  198 |   })
-  199 |   test('#watch', () => {
+  212 |   })
+  213 |   test('#watch', () => {
 
-  193 | 
-  194 |     //const check1: Event<string> = computed
-> 195 |     const event_map_check2: Event<number> = computed
+  207 | 
+  208 |     //const check1: Event<string> = computed
+> 209 |     const event_map_check2: Event<number> = computed
       |                                   ^^^^^^ [2]
-  196 |     event(2)
-  197 |     computed('')
+  210 |     event(2)
+  211 |     computed('')
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  219 |       const event: Event<number> = createEvent()
-  220 |       const filteredEvent_error: Event<number> = event.filter(n => {
-> 221 |         if (n % 2) return n.toString()
+  233 |       const event: Event<number> = createEvent()
+  234 |       const filteredEvent_error: Event<number> = event.filter(n => {
+> 235 |         if (n % 2) return n.toString()
       |                           ^^^^^^^^^^^ 
       |  Cannot assign \`event.filter(...)\` to \`filteredEvent_error\` 
       |  because string [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  222 |       })
-  223 |     })
+  236 |       })
+  237 |     })
 
    [LIB] core.js
 > 158 |     toString(radix?: number): string;
       |                               ^^^^^^ [1]
 
   src/types/types.test.js
-  218 |     test('#filter incorrect', () => {
-  219 |       const event: Event<number> = createEvent()
-> 220 |       const filteredEvent_error: Event<number> = event.filter(n => {
+  232 |     test('#filter incorrect', () => {
+  233 |       const event: Event<number> = createEvent()
+> 234 |       const filteredEvent_error: Event<number> = event.filter(n => {
       |                                        ^^^^^^ [2]
-  221 |         if (n % 2) return n.toString()
-  222 |       })
+  235 |         if (n % 2) return n.toString()
+  236 |       })
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  267 |       test('no false-positive (should be type error)', () => {
-  268 |         const nestedEffect: Effect<string, string> = createEffect()
-> 269 |         const parentEffect: Effect<number, number> = createEffect(
+  295 |       test('no false-positive (should be type error)', () => {
+  296 |         const nestedEffect: Effect<string, string> = createEffect()
+> 297 |         const parentEffect: Effect<number, number> = createEffect(
       |                                                      ^^^^^^^^^^^^
-> 270 |           'should not throw',
+> 298 |           'should not throw',
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 271 |           {
+> 299 |           {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 272 |             handler: nestedEffect,
+> 300 |             handler: nestedEffect,
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 273 |           },
+> 301 |           },
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 274 |         )
+> 302 |         )
       | ^^^^^^^^^ 
       |  Cannot assign \`createEffect(...)\` to \`parentEffect\` 
       |  because number [1] is incompatible with string [2] in type
       |  argument \`Params\` [3].
       |  
-  275 |       })
-  276 |     })
+  303 |       })
+  304 |     })
 
-  267 |       test('no false-positive (should be type error)', () => {
-  268 |         const nestedEffect: Effect<string, string> = createEffect()
-> 269 |         const parentEffect: Effect<number, number> = createEffect(
+  295 |       test('no false-positive (should be type error)', () => {
+  296 |         const nestedEffect: Effect<string, string> = createEffect()
+> 297 |         const parentEffect: Effect<number, number> = createEffect(
       |                                    ^^^^^^ [1]
-  270 |           'should not throw',
-  271 |           {
+  298 |           'should not throw',
+  299 |           {
 
-  266 |     describe('with handler', () => {
-  267 |       test('no false-positive (should be type error)', () => {
-> 268 |         const nestedEffect: Effect<string, string> = createEffect()
+  294 |     describe('with handler', () => {
+  295 |       test('no false-positive (should be type error)', () => {
+> 296 |         const nestedEffect: Effect<string, string> = createEffect()
       |                                    ^^^^^^ [2]
-  269 |         const parentEffect: Effect<number, number> = createEffect(
-  270 |           'should not throw',
+  297 |         const parentEffect: Effect<number, number> = createEffect(
+  298 |           'should not throw',
 
   packages/effector/index.js.flow
-   54 | }
-   55 | 
->  56 | declare export class Effect<Params, Done, Fail = Error>
+   64 | }
+   65 | 
+>  66 | declare export class Effect<Params, Done, Fail = Error>
       |                             ^^^^^^ [3]
-   57 |   implements Unit<Params> {
-   58 |   (payload: Params): Promise<Done>;
+   67 |   implements Unit<Params> {
+   68 |   (payload: Params): Promise<Done>;
 
   
 
   src/types/types.test.js
-  267 |       test('no false-positive (should be type error)', () => {
-  268 |         const nestedEffect: Effect<string, string> = createEffect()
-> 269 |         const parentEffect: Effect<number, number> = createEffect(
+  295 |       test('no false-positive (should be type error)', () => {
+  296 |         const nestedEffect: Effect<string, string> = createEffect()
+> 297 |         const parentEffect: Effect<number, number> = createEffect(
       |                                                      ^^^^^^^^^^^^
-> 270 |           'should not throw',
+> 298 |           'should not throw',
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 271 |           {
+> 299 |           {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 272 |             handler: nestedEffect,
+> 300 |             handler: nestedEffect,
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 273 |           },
+> 301 |           },
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-> 274 |         )
+> 302 |         )
       | ^^^^^^^^^ 
       |  Cannot assign \`createEffect(...)\` to \`parentEffect\` 
       |  because string [1] is incompatible with number [2] in type argument \`Done\` [3].
       |  
-  275 |       })
-  276 |     })
+  303 |       })
+  304 |     })
 
-  266 |     describe('with handler', () => {
-  267 |       test('no false-positive (should be type error)', () => {
-> 268 |         const nestedEffect: Effect<string, string> = createEffect()
+  294 |     describe('with handler', () => {
+  295 |       test('no false-positive (should be type error)', () => {
+> 296 |         const nestedEffect: Effect<string, string> = createEffect()
       |                                            ^^^^^^ [1]
-  269 |         const parentEffect: Effect<number, number> = createEffect(
-  270 |           'should not throw',
+  297 |         const parentEffect: Effect<number, number> = createEffect(
+  298 |           'should not throw',
 
-  267 |       test('no false-positive (should be type error)', () => {
-  268 |         const nestedEffect: Effect<string, string> = createEffect()
-> 269 |         const parentEffect: Effect<number, number> = createEffect(
+  295 |       test('no false-positive (should be type error)', () => {
+  296 |         const nestedEffect: Effect<string, string> = createEffect()
+> 297 |         const parentEffect: Effect<number, number> = createEffect(
       |                                            ^^^^^^ [2]
-  270 |           'should not throw',
-  271 |           {
+  298 |           'should not throw',
+  299 |           {
 
   packages/effector/index.js.flow
-   54 | }
-   55 | 
->  56 | declare export class Effect<Params, Done, Fail = Error>
+   64 | }
+   65 | 
+>  66 | declare export class Effect<Params, Done, Fail = Error>
       |                                     ^^^^ [3]
-   57 |   implements Unit<Params> {
-   58 |   (payload: Params): Promise<Done>;
+   67 |   implements Unit<Params> {
+   68 |   (payload: Params): Promise<Done>;
 
   
 
   src/types/types.test.js
-  282 |   test('createStore', () => {
-  283 |     const createStore_store1: Store<number> = createStore(0)
-> 284 |     const createStore_store2: Store<string> = createStore(0)
+  310 |   test('createStore', () => {
+  311 |     const createStore_store1: Store<number> = createStore(0)
+> 312 |     const createStore_store2: Store<string> = createStore(0)
       |                                                           ^ 
       |  Cannot assign \`createStore(...)\` to \`createStore_store2\` 
       |  because number [1] is incompatible with string [2] in type argument \`State\` [3].
       |  
-  285 |   })
-  286 |   test('createStoreObject', () => {
+  313 |   })
+  314 |   test('createStoreObject', () => {
 
-  282 |   test('createStore', () => {
-  283 |     const createStore_store1: Store<number> = createStore(0)
-> 284 |     const createStore_store2: Store<string> = createStore(0)
+  310 |   test('createStore', () => {
+  311 |     const createStore_store1: Store<number> = createStore(0)
+> 312 |     const createStore_store2: Store<string> = createStore(0)
       |                                                           ^^ [1]
-  285 |   })
-  286 |   test('createStoreObject', () => {
+  313 |   })
+  314 |   test('createStoreObject', () => {
 
-  282 |   test('createStore', () => {
-  283 |     const createStore_store1: Store<number> = createStore(0)
-> 284 |     const createStore_store2: Store<string> = createStore(0)
+  310 |   test('createStore', () => {
+  311 |     const createStore_store1: Store<number> = createStore(0)
+> 312 |     const createStore_store2: Store<string> = createStore(0)
       |                                     ^^^^^^ [2]
-  285 |   })
-  286 |   test('createStoreObject', () => {
+  313 |   })
+  314 |   test('createStoreObject', () => {
 
   packages/effector/index.js.flow
-   90 | }
-   91 | 
->  92 | declare export class Store<State> implements Unit<State> {
+  103 | }
+  104 | 
+> 105 | declare export class Store<State> implements Unit<State> {
       |                            ^^^^^ [3]
-   93 |   +kind: kind;
-   94 |   reset(...triggers: Array<Unit<any>>): this;
+  106 |   +kind: kind;
+  107 |   reset(...triggers: Array<Unit<any>>): this;
 
   
 
   src/types/types.test.js
-  305 |         event: (n, x: number) => x,
-  306 |       })
-> 307 |       const createApi_check2: Event<string> = event
+  333 |         event: (n, x: number) => x,
+  334 |       })
+> 335 |       const createApi_check2: Event<string> = event
       |                                               ^^^^ 
       |  Cannot assign \`event\` to \`createApi_check2\` 
       |  because string [1] is incompatible with number [2] in type argument
       |  \`Payload\` [3].
       |  
-  308 |     }
-  309 |     {
+  336 |     }
+  337 |     {
 
-  305 |         event: (n, x: number) => x,
-  306 |       })
-> 307 |       const createApi_check2: Event<string> = event
+  333 |         event: (n, x: number) => x,
+  334 |       })
+> 335 |       const createApi_check2: Event<string> = event
       |                                     ^^^^^^ [1]
-  308 |     }
-  309 |     {
+  336 |     }
+  337 |     {
 
-  303 |     {
-  304 |       const {event} = createApi(store, {
-> 305 |         event: (n, x: number) => x,
+  331 |     {
+  332 |       const {event} = createApi(store, {
+> 333 |         event: (n, x: number) => x,
       |                       ^^^^^^ [2]
-  306 |       })
-  307 |       const createApi_check2: Event<string> = event
+  334 |       })
+  335 |       const createApi_check2: Event<string> = event
 
   packages/effector/index.js.flow
-   35 |   +kind: kind;
-   36 | }
->  37 | declare export class Event<Payload> implements Unit<Payload> {
+   42 | |}
+   43 | 
+>  44 | declare export class Event<Payload> implements Unit<Payload> {
       |                            ^^^^^^^ [3]
-   38 |   (payload: Payload): Payload;
-   39 |   +kind: kind;
+   45 |   (payload: Payload): Payload;
+   46 |   +kind: kind;
 
   
 
   src/types/types.test.js
-  309 |     {
-  310 |       const {event} = createApi(store, {
-> 311 |         event: (n, x) => x,
+  337 |     {
+  338 |       const {event} = createApi(store, {
+> 339 |         event: (n, x) => x,
       |                          ^ 
       |  Cannot call \`createApi\` with object literal bound to \`api\` 
       |  because string [1] is incompatible with number [2] in the return value of
       |  property \`event\`.
       |  
-  312 |       })
-  313 |       const createApi_check3: Event<string> = event
+  340 |       })
+  341 |       const createApi_check3: Event<string> = event
 
-  311 |         event: (n, x) => x,
-  312 |       })
-> 313 |       const createApi_check3: Event<string> = event
+  339 |         event: (n, x) => x,
+  340 |       })
+> 341 |       const createApi_check3: Event<string> = event
       |                                     ^^^^^^ [1]
-  314 |     }
-  315 |   })
+  342 |     }
+  343 |   })
 
-  294 |   })
-  295 |   test('createApi', () => {
-> 296 |     const store: Store<number> = createStore(0)
+  322 |   })
+  323 |   test('createApi', () => {
+> 324 |     const store: Store<number> = createStore(0)
       |                        ^^^^^^ [2]
-  297 |     {
-  298 |       const {event} = createApi(store, {
+  325 |     {
+  326 |       const {event} = createApi(store, {
 
   
 
   src/types/types.test.js
-  367 |     const map_check1: Store<string> = computed
-  368 | 
-> 369 |     const map_check2: Store<number> = computed
+  395 |     const map_check1: Store<string> = computed
+  396 | 
+> 397 |     const map_check2: Store<number> = computed
       |                                       ^^^^^^^ 
       |  Cannot assign \`computed\` to \`map_check2\` 
       |  because string [1] is incompatible with number [2] in type argument \`State\` [3].
       |  
-  370 |   })
-  371 | 
+  398 |   })
+  399 | 
 
-  365 |     const computed = store.map(() => 'hello')
-  366 | 
-> 367 |     const map_check1: Store<string> = computed
+  393 |     const computed = store.map(() => 'hello')
+  394 | 
+> 395 |     const map_check1: Store<string> = computed
       |                             ^^^^^^ [1]
-  368 | 
-  369 |     const map_check2: Store<number> = computed
+  396 | 
+  397 |     const map_check2: Store<number> = computed
 
-  367 |     const map_check1: Store<string> = computed
-  368 | 
-> 369 |     const map_check2: Store<number> = computed
+  395 |     const map_check1: Store<string> = computed
+  396 | 
+> 397 |     const map_check2: Store<number> = computed
       |                             ^^^^^^ [2]
-  370 |   })
-  371 | 
+  398 |   })
+  399 | 
 
   packages/effector/index.js.flow
-   90 | }
-   91 | 
->  92 | declare export class Store<State> implements Unit<State> {
+  103 | }
+  104 | 
+> 105 | declare export class Store<State> implements Unit<State> {
       |                            ^^^^^ [3]
-   93 |   +kind: kind;
-   94 |   reset(...triggers: Array<Unit<any>>): this;
+  106 |   +kind: kind;
+  107 |   reset(...triggers: Array<Unit<any>>): this;
 
   
 
   src/types/types.test.js
-  449 |     const domain = createDomain()
-  450 |     const domain2 = createDomain('hello')
-> 451 |     const domain3 = createDomain(234)
+  477 |     const domain = createDomain()
+  478 |     const domain2 = createDomain('hello')
+> 479 |     const domain3 = createDomain(234)
       |                                  ^^ 
       |  Cannot call \`createDomain\` with \`234\` bound to \`domainName\` 
       |  because number [1] is incompatible with string [2].
       |  
-  452 |     const domain4 = createDomain({foo: true})
-  453 |   })
+  480 |     const domain4 = createDomain({foo: true})
+  481 |   })
 
-  449 |     const domain = createDomain()
-  450 |     const domain2 = createDomain('hello')
-> 451 |     const domain3 = createDomain(234)
+  477 |     const domain = createDomain()
+  478 |     const domain2 = createDomain('hello')
+> 479 |     const domain3 = createDomain(234)
       |                                  ^^^ [1]
-  452 |     const domain4 = createDomain({foo: true})
-  453 |   })
+  480 |     const domain4 = createDomain({foo: true})
+  481 |   })
 
   packages/effector/index.js.flow
-  340 |   <S>(field: Store<S> | S) => Store<S>,
-  341 | >
-> 342 | declare export function createDomain(domainName?: string): Domain
+  355 |   <S>(field: Store<S> | S) => Store<S>,
+  356 | >
+> 357 | declare export function createDomain(domainName?: string): Domain
       |                                                   ^^^^^^ [2]
-  343 | 
-  344 | declare export function sample<A>(config: {|
+  358 | 
+  359 | declare export function sample<A>(config: {|
 
   
 
   src/types/types.test.js
-  450 |     const domain2 = createDomain('hello')
-  451 |     const domain3 = createDomain(234)
-> 452 |     const domain4 = createDomain({foo: true})
+  478 |     const domain2 = createDomain('hello')
+  479 |     const domain3 = createDomain(234)
+> 480 |     const domain4 = createDomain({foo: true})
       |                                  ^^^^^^^^^^ 
       |  Cannot call \`createDomain\` with object literal bound to \`domainName\` 
       |  because object literal [1] is incompatible with string [2].
       |  
-  453 |   })
-  454 | 
+  481 |   })
+  482 | 
 
-  450 |     const domain2 = createDomain('hello')
-  451 |     const domain3 = createDomain(234)
-> 452 |     const domain4 = createDomain({foo: true})
+  478 |     const domain2 = createDomain('hello')
+  479 |     const domain3 = createDomain(234)
+> 480 |     const domain4 = createDomain({foo: true})
       |                                  ^^^^^^^^^^^ [1]
-  453 |   })
-  454 | 
+  481 |   })
+  482 | 
 
   packages/effector/index.js.flow
-  340 |   <S>(field: Store<S> | S) => Store<S>,
-  341 | >
-> 342 | declare export function createDomain(domainName?: string): Domain
+  355 |   <S>(field: Store<S> | S) => Store<S>,
+  356 | >
+> 357 | declare export function createDomain(domainName?: string): Domain
       |                                                   ^^^^^^ [2]
-  343 | 
-  344 | declare export function sample<A>(config: {|
+  358 | 
+  359 | declare export function sample<A>(config: {|
 
   
 
   src/types/types.test.js
-  466 |       },
-  467 |     })
-> 468 |     effect2(20)
+  494 |       },
+  495 |     })
+> 496 |     effect2(20)
       |             ^ 
       |  Cannot call \`effect2\` with \`20\` bound to \`payload\` 
       |  because number [1] is incompatible with string [2].
       |  
-  469 |     const effect3 = domain.effect('', {
-  470 |       handler: effect1,
+  497 |     const effect3 = domain.effect('', {
+  498 |       handler: effect1,
 
-  466 |       },
-  467 |     })
-> 468 |     effect2(20)
+  494 |       },
+  495 |     })
+> 496 |     effect2(20)
       |             ^^ [1]
-  469 |     const effect3 = domain.effect('', {
-  470 |       handler: effect1,
+  497 |     const effect3 = domain.effect('', {
+  498 |       handler: effect1,
 
-  462 |     const effect1: Effect<string, number, Error> = domain.effect()
-  463 |     const effect2 = domain.effect('', {
-> 464 |       handler(params: string) {
+  490 |     const effect1: Effect<string, number, Error> = domain.effect()
+  491 |     const effect2 = domain.effect('', {
+> 492 |       handler(params: string) {
       |                       ^^^^^^ [2]
-  465 |         return 256
-  466 |       },
+  493 |         return 256
+  494 |       },
 
   
 
   src/types/types.test.js
-  470 |       handler: effect1,
-  471 |     })
-> 472 |     effect3(20)
+  498 |       handler: effect1,
+  499 |     })
+> 500 |     effect3(20)
       |             ^ 
       |  Cannot call \`effect3\` with \`20\` bound to \`payload\` 
       |  because number [1] is incompatible with string [2].
       |  
-  473 |   })
-  474 | 
+  501 |   })
+  502 | 
 
-  470 |       handler: effect1,
-  471 |     })
-> 472 |     effect3(20)
+  498 |       handler: effect1,
+  499 |     })
+> 500 |     effect3(20)
       |             ^^ [1]
-  473 |   })
-  474 | 
+  501 |   })
+  502 | 
 
-  460 |   test('#effect', () => {
-  461 |     const domain = createDomain()
-> 462 |     const effect1: Effect<string, number, Error> = domain.effect()
+  488 |   test('#effect', () => {
+  489 |     const domain = createDomain()
+> 490 |     const effect1: Effect<string, number, Error> = domain.effect()
       |                           ^^^^^^ [2]
-  463 |     const effect2 = domain.effect('', {
-  464 |       handler(params: string) {
+  491 |     const effect2 = domain.effect('', {
+  492 |       handler(params: string) {
 
   
 
   src/types/types.test.js
-  556 |       ],
-  557 |     })
-> 558 |     launch(foo, '')
+  584 |       ],
+  585 |     })
+> 586 |     launch(foo, '')
       |                 ^ 
       |  Cannot call \`launch\` with empty string bound to \`payload\` 
       |  because string [1] is incompatible with number [2].
       |  
-  559 |     launch(foo, 0)
-  560 |     launch(customNode, 100)
+  587 |     launch(foo, 0)
+  588 |     launch(customNode, 100)
 
-  556 |       ],
-  557 |     })
-> 558 |     launch(foo, '')
+  584 |       ],
+  585 |     })
+> 586 |     launch(foo, '')
       |                 ^^ [1]
-  559 |     launch(foo, 0)
-  560 |     launch(customNode, 100)
+  587 |     launch(foo, 0)
+  588 |     launch(customNode, 100)
 
-  537 | 
-  538 |   test('launch', () => {
-> 539 |     const foo = createEvent<number>()
+  565 | 
+  566 |   test('launch', () => {
+> 567 |     const foo = createEvent<number>()
       |                             ^^^^^^ [2]
-  540 |     const customNode = createNode({
-  541 |       scope: {max: 100, lastValue: -1, add: 10},
+  568 |     const customNode = createNode({
+  569 |       scope: {max: 100, lastValue: -1, add: 10},
 
   
 
   src/types/types.test.js
-  588 |       (initialProps: {id: number}) => {
-  589 |         const createComponent_initialProps_check1: number = initialProps.id
-> 590 |         const createComponent_initialProps_check2: string = initialProps.id
+  616 |       (initialProps: {id: number}) => {
+  617 |         const createComponent_initialProps_check1: number = initialProps.id
+> 618 |         const createComponent_initialProps_check2: string = initialProps.id
       |                                                             ^^^^^^^^^^^^^^ 
       |  Cannot assign \`initialProps.id\` to \`createComponent_initialProps_check2\` 
       |  because number [1] is incompatible with string [2].
       |  
-  591 |         const createComponent_initialProps_check3: string =
-  592 |           initialProps.unknownProp
+  619 |         const createComponent_initialProps_check3: string =
+  620 |           initialProps.unknownProp
 
-  586 |     }>({})
-  587 |     const InitialProps = createComponent(
-> 588 |       (initialProps: {id: number}) => {
+  614 |     }>({})
+  615 |     const InitialProps = createComponent(
+> 616 |       (initialProps: {id: number}) => {
       |                           ^^^^^^ [1]
-  589 |         const createComponent_initialProps_check1: number = initialProps.id
-  590 |         const createComponent_initialProps_check2: string = initialProps.id
+  617 |         const createComponent_initialProps_check1: number = initialProps.id
+  618 |         const createComponent_initialProps_check2: string = initialProps.id
 
-  588 |       (initialProps: {id: number}) => {
-  589 |         const createComponent_initialProps_check1: number = initialProps.id
-> 590 |         const createComponent_initialProps_check2: string = initialProps.id
+  616 |       (initialProps: {id: number}) => {
+  617 |         const createComponent_initialProps_check1: number = initialProps.id
+> 618 |         const createComponent_initialProps_check2: string = initialProps.id
       |                                                    ^^^^^^ [2]
-  591 |         const createComponent_initialProps_check3: string =
-  592 |           initialProps.unknownProp
+  619 |         const createComponent_initialProps_check3: string =
+  620 |           initialProps.unknownProp
 
   
 
   src/types/types.test.js
-  590 |         const createComponent_initialProps_check2: string = initialProps.id
-  591 |         const createComponent_initialProps_check3: string =
-> 592 |           initialProps.unknownProp
+  618 |         const createComponent_initialProps_check2: string = initialProps.id
+  619 |         const createComponent_initialProps_check3: string =
+> 620 |           initialProps.unknownProp
       |                        ^^^^^^^^^^ 
       |  Cannot get \`initialProps.unknownProp\` 
       |  because property \`unknownProp\` is missing in object type [1].
       |  
-  593 |         return list.map(list => list[initialProps.id] || {text: 'Loading...'})
-  594 |       },
+  621 |         return list.map(list => list[initialProps.id] || {text: 'Loading...'})
+  622 |       },
 
-  586 |     }>({})
-  587 |     const InitialProps = createComponent(
-> 588 |       (initialProps: {id: number}) => {
+  614 |     }>({})
+  615 |     const InitialProps = createComponent(
+> 616 |       (initialProps: {id: number}) => {
       |                      ^^^^^^^^^^^^ [1]
-  589 |         const createComponent_initialProps_check1: number = initialProps.id
-  590 |         const createComponent_initialProps_check2: string = initialProps.id
+  617 |         const createComponent_initialProps_check1: number = initialProps.id
+  618 |         const createComponent_initialProps_check2: string = initialProps.id
 
   
 
   src/types/types.test.js
-  595 |       (_, state) => {
-  596 |         const createComponent_initialProps_check4: string = state.text
-> 597 |         const createComponent_initialProps_check5: number = state.text
+  623 |       (_, state) => {
+  624 |         const createComponent_initialProps_check4: string = state.text
+> 625 |         const createComponent_initialProps_check5: number = state.text
       |                                                             ^^^^^^^^^ 
       |  Cannot assign \`state.text\` to \`createComponent_initialProps_check5\` 
       |  because string [1] is incompatible with number [2].
       |  
-  598 |         return null
-  599 |       },
+  626 |         return null
+  627 |       },
 
-  582 |     const list = createStore<{
-  583 |       [key: number]: {
-> 584 |         text: string,
+  610 |     const list = createStore<{
+  611 |       [key: number]: {
+> 612 |         text: string,
       |               ^^^^^^ [1]
-  585 |       },
-  586 |     }>({})
+  613 |       },
+  614 |     }>({})
 
-  595 |       (_, state) => {
-  596 |         const createComponent_initialProps_check4: string = state.text
-> 597 |         const createComponent_initialProps_check5: number = state.text
+  623 |       (_, state) => {
+  624 |         const createComponent_initialProps_check4: string = state.text
+> 625 |         const createComponent_initialProps_check5: number = state.text
       |                                                    ^^^^^^ [2]
-  598 |         return null
-  599 |       },
+  626 |         return null
+  627 |       },
 
   
 
   src/types/types.test.js
-  602 | 
-  603 |   test('createGate', () => {
-> 604 |     const Foo = createGate<number>('foo')
+  630 | 
+  631 |   test('createGate', () => {
+> 632 |     const Foo = createGate<number>('foo')
       |                            ^^^^^ 
       |  Cannot call \`createGate\` 
       |  because number [1] is incompatible with object type [2] in type
       |  argument \`Props\`.
       |  
-  605 |     const Bar = createGate<{a: number}>('bar')
-  606 |     const Baz = createGate<number | null>('baz', null)
+  633 |     const Bar = createGate<{a: number}>('bar')
+  634 |     const Baz = createGate<number | null>('baz', null)
 
-  602 | 
-  603 |   test('createGate', () => {
-> 604 |     const Foo = createGate<number>('foo')
+  630 | 
+  631 |   test('createGate', () => {
+> 632 |     const Foo = createGate<number>('foo')
       |                            ^^^^^^ [1]
-  605 |     const Bar = createGate<{a: number}>('bar')
-  606 |     const Baz = createGate<number | null>('baz', null)
+  633 |     const Bar = createGate<{a: number}>('bar')
+  634 |     const Baz = createGate<number | null>('baz', null)
 
   packages/effector-react/index.js.flow
    57 | declare export function useGate<Props>(Gate: Gate<Props>, props?: Props): void
@@ -1147,29 +1147,29 @@ exports[`Flow: json messages 1`] = `
   
 
   src/types/types.test.js
-  608 |     const Component = () => {
-  609 |       useGate(Foo, 1)
-> 610 |       useGate(Bar, 1)
+  636 |     const Component = () => {
+  637 |       useGate(Foo, 1)
+> 638 |       useGate(Bar, 1)
       |                    ^ 
       |  Cannot call \`useGate\` with \`1\` bound to \`props\` 
       |  because number [1] is incompatible with object type [2].
       |  
-  611 |       useGate(Bar, {a: 1})
-  612 |       useGate(Bar, {})
+  639 |       useGate(Bar, {a: 1})
+  640 |       useGate(Bar, {})
 
-  608 |     const Component = () => {
-  609 |       useGate(Foo, 1)
-> 610 |       useGate(Bar, 1)
+  636 |     const Component = () => {
+  637 |       useGate(Foo, 1)
+> 638 |       useGate(Bar, 1)
       |                    ^^ [1]
-  611 |       useGate(Bar, {a: 1})
-  612 |       useGate(Bar, {})
+  639 |       useGate(Bar, {a: 1})
+  640 |       useGate(Bar, {})
 
-  603 |   test('createGate', () => {
-  604 |     const Foo = createGate<number>('foo')
-> 605 |     const Bar = createGate<{a: number}>('bar')
+  631 |   test('createGate', () => {
+  632 |     const Foo = createGate<number>('foo')
+> 633 |     const Bar = createGate<{a: number}>('bar')
       |                            ^^^^^^^^^^^ [2]
-  606 |     const Baz = createGate<number | null>('baz', null)
-  607 | 
+  634 |     const Baz = createGate<number | null>('baz', null)
+  635 | 
 
   "
 `;
@@ -1177,64 +1177,64 @@ exports[`Flow: json messages 1`] = `
 exports[`TypeScript: rejected 1`] = `
 "Command failed: npx tsc -p src/types
 
-types.test.ts(58,17): Type 'Event<string[]>' is not assignable to type 'Event<number>'.
+types.test.ts(59,17): Type 'Event<string[]>' is not assignable to type 'Event<number>'.
   Type 'string[]' is not assignable to type 'number'.
-types.test.ts(59,17): Type 'Event<string[]>' is not assignable to type 'null'.
-types.test.ts(67,17): Type 'Event<string[]>' is not assignable to type 'Event<number>'.
-types.test.ts(75,17): Type 'Event<string[]>' is not assignable to type 'null'.
-types.test.ts(83,30): Type 'null' is not assignable to type 'boolean'.
-types.test.ts(84,9): Type '(list: null) => true' is not assignable to type '(payload: string[]) => boolean'.
+types.test.ts(60,17): Type 'Event<string[]>' is not assignable to type 'null'.
+types.test.ts(68,17): Type 'Event<string[]>' is not assignable to type 'Event<number>'.
+types.test.ts(76,17): Type 'Event<string[]>' is not assignable to type 'null'.
+types.test.ts(84,30): Type 'null' is not assignable to type 'boolean'.
+types.test.ts(85,9): Type '(list: null) => true' is not assignable to type '(payload: string[]) => boolean'.
   Types of parameters 'list' and 'payload' are incompatible.
     Type 'string[]' is not assignable to type 'null'.
-types.test.ts(85,9): Type '(list: number[]) => true' is not assignable to type '(payload: string[]) => boolean'.
+types.test.ts(86,9): Type '(list: number[]) => true' is not assignable to type '(payload: string[]) => boolean'.
   Types of parameters 'list' and 'payload' are incompatible.
     Type 'string[]' is not assignable to type 'number[]'.
       Type 'string' is not assignable to type 'number'.
-types.test.ts(96,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
-types.test.ts(104,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
+types.test.ts(97,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
+types.test.ts(105,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
-types.test.ts(113,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
-types.test.ts(121,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
+types.test.ts(114,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
+types.test.ts(122,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
-types.test.ts(130,13): Type 'Event<string>' is not assignable to type 'Event<number>'.
-types.test.ts(138,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<number>'.
+types.test.ts(131,13): Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts(139,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<number>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'number'.
-types.test.ts(147,13): Type 'Store<boolean>' is not assignable to type 'Store<string>'.
+types.test.ts(148,13): Type 'Store<boolean>' is not assignable to type 'Store<string>'.
   Type 'boolean' is not assignable to type 'string'.
-types.test.ts(155,13): Type 'Store<{ a: string; b: boolean; }>' is not assignable to type 'Store<string>'.
+types.test.ts(156,13): Type 'Store<{ a: string; b: boolean; }>' is not assignable to type 'Store<string>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
-types.test.ts(164,15): Type 'Store<string>' is not assignable to type 'Store<number>'.
-types.test.ts(175,17): Type 'Event<string>' is not assignable to type 'Event<number>'.
-types.test.ts(195,11): Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts(165,15): Type 'Store<string>' is not assignable to type 'Store<number>'.
+types.test.ts(176,17): Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts(209,11): Type 'Event<string>' is not assignable to type 'Event<number>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(220,13): Type 'Event<string>' is not assignable to type 'Event<number>'.
-types.test.ts(250,17): Argument of type 'Effect<number, string, any>' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
+types.test.ts(234,13): Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts(278,17): Argument of type 'Effect<number, string, any>' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
   Types of parameters 'payload' and 'params' are incompatible.
     Type '{}' is not assignable to type 'number'.
-types.test.ts(257,7): Expected 1 arguments, but got 0.
-types.test.ts(261,43): Argument of type '() => void' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
+types.test.ts(285,7): Expected 1 arguments, but got 0.
+types.test.ts(289,43): Argument of type '() => void' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
   Type 'void' is not assignable to type '{} | Promise<{}>'.
-types.test.ts(269,15): Type 'Effect<string, string, Error>' is not assignable to type 'Effect<number, number, Error>'.
+types.test.ts(297,15): Type 'Effect<string, string, Error>' is not assignable to type 'Effect<number, number, Error>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(284,11): Type 'Store<number>' is not assignable to type 'Store<string>'.
+types.test.ts(312,11): Type 'Store<number>' is not assignable to type 'Store<string>'.
   Type 'number' is not assignable to type 'string'.
-types.test.ts(307,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
+types.test.ts(335,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
   Type 'number' is not assignable to type 'string'.
-types.test.ts(313,13): Type 'Event<void>' is not assignable to type 'Event<string>'.
+types.test.ts(341,13): Type 'Event<void>' is not assignable to type 'Event<string>'.
   Type 'void' is not assignable to type 'string'.
-types.test.ts(369,11): Type 'Store<string>' is not assignable to type 'Store<number>'.
+types.test.ts(397,11): Type 'Store<string>' is not assignable to type 'Store<number>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(451,34): Argument of type '234' is not assignable to parameter of type 'string | undefined'.
-types.test.ts(452,34): Argument of type '{ foo: boolean; }' is not assignable to parameter of type 'string'.
-types.test.ts(468,13): Argument of type '20' is not assignable to parameter of type 'string'.
-types.test.ts(472,13): Argument of type '20' is not assignable to parameter of type 'string'.
-types.test.ts(558,17): Argument of type '\\"\\"' is not assignable to parameter of type 'number'.
-types.test.ts(590,15): Type 'number' is not assignable to type 'string'.
-types.test.ts(592,24): Property 'unknownProp' does not exist on type '{ id: number; }'.
-types.test.ts(597,15): Type 'string' is not assignable to type 'number'.
-types.test.ts(604,28): Type 'number' does not satisfy the constraint 'object'.
-types.test.ts(610,20): Argument of type '1' is not assignable to parameter of type '{ a: number; } | undefined'.
-types.test.ts(612,20): Argument of type '{}' is not assignable to parameter of type '{ a: number; }'.
+types.test.ts(479,34): Argument of type '234' is not assignable to parameter of type 'string | undefined'.
+types.test.ts(480,34): Argument of type '{ foo: boolean; }' is not assignable to parameter of type 'string'.
+types.test.ts(496,13): Argument of type '20' is not assignable to parameter of type 'string'.
+types.test.ts(500,13): Argument of type '20' is not assignable to parameter of type 'string'.
+types.test.ts(586,17): Argument of type '\\"\\"' is not assignable to parameter of type 'number'.
+types.test.ts(618,15): Type 'number' is not assignable to type 'string'.
+types.test.ts(620,24): Property 'unknownProp' does not exist on type '{ id: number; }'.
+types.test.ts(625,15): Type 'string' is not assignable to type 'number'.
+types.test.ts(632,28): Type 'number' does not satisfy the constraint 'object'.
+types.test.ts(638,20): Argument of type '1' is not assignable to parameter of type '{ a: number; } | undefined'.
+types.test.ts(640,20): Argument of type '{}' is not assignable to parameter of type '{ a: number; }'.
   Property 'a' is missing in type '{}' but required in type '{ a: number; }'.
 useStoreMap.test.tsx(50,28): Tuple type 'readonly [number]' of length '1' has no element at index '1'.
 useStoreMap.test.tsx(71,11): Type '[number, \\"username\\" | \\"email\\" | \\"bio\\"]' is not assignable to type '[number, number]'.

--- a/src/types/__tests__/__snapshots__/run-tests.test.js.snap
+++ b/src/types/__tests__/__snapshots__/run-tests.test.js.snap
@@ -1177,69 +1177,69 @@ exports[`Flow: json messages 1`] = `
 exports[`TypeScript: rejected 1`] = `
 "Command failed: npx tsc -p src/types
 
-types.test.ts(59,17): Type 'Event<string[]>' is not assignable to type 'Event<number>'.
+types.test.ts: Type 'Event<string[]>' is not assignable to type 'Event<number>'.
   Type 'string[]' is not assignable to type 'number'.
-types.test.ts(60,17): Type 'Event<string[]>' is not assignable to type 'null'.
-types.test.ts(68,17): Type 'Event<string[]>' is not assignable to type 'Event<number>'.
-types.test.ts(76,17): Type 'Event<string[]>' is not assignable to type 'null'.
-types.test.ts(84,30): Type 'null' is not assignable to type 'boolean'.
-types.test.ts(85,9): Type '(list: null) => true' is not assignable to type '(payload: string[]) => boolean'.
+types.test.ts: Type 'Event<string[]>' is not assignable to type 'null'.
+types.test.ts: Type 'Event<string[]>' is not assignable to type 'Event<number>'.
+types.test.ts: Type 'Event<string[]>' is not assignable to type 'null'.
+types.test.ts: Type 'null' is not assignable to type 'boolean'.
+types.test.ts: Type '(list: null) => true' is not assignable to type '(payload: string[]) => boolean'.
   Types of parameters 'list' and 'payload' are incompatible.
     Type 'string[]' is not assignable to type 'null'.
-types.test.ts(86,9): Type '(list: number[]) => true' is not assignable to type '(payload: string[]) => boolean'.
+types.test.ts: Type '(list: number[]) => true' is not assignable to type '(payload: string[]) => boolean'.
   Types of parameters 'list' and 'payload' are incompatible.
     Type 'string[]' is not assignable to type 'number[]'.
       Type 'string' is not assignable to type 'number'.
-types.test.ts(97,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
-types.test.ts(105,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
+types.test.ts: Type 'Event<number>' is not assignable to type 'Event<string>'.
+types.test.ts: Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
-types.test.ts(114,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
-types.test.ts(122,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
+types.test.ts: Type 'Event<number>' is not assignable to type 'Event<string>'.
+types.test.ts: Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<string>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
-types.test.ts(131,13): Type 'Event<string>' is not assignable to type 'Event<number>'.
-types.test.ts(139,13): Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<number>'.
+types.test.ts: Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts: Type 'Event<{ a: string; b: boolean; }>' is not assignable to type 'Event<number>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'number'.
-types.test.ts(148,13): Type 'Store<boolean>' is not assignable to type 'Store<string>'.
+types.test.ts: Type 'Store<boolean>' is not assignable to type 'Store<string>'.
   Type 'boolean' is not assignable to type 'string'.
-types.test.ts(156,13): Type 'Store<{ a: string; b: boolean; }>' is not assignable to type 'Store<string>'.
+types.test.ts: Type 'Store<{ a: string; b: boolean; }>' is not assignable to type 'Store<string>'.
   Type '{ a: string; b: boolean; }' is not assignable to type 'string'.
-types.test.ts(165,15): Type 'Store<string>' is not assignable to type 'Store<number>'.
-types.test.ts(176,17): Type 'Event<string>' is not assignable to type 'Event<number>'.
-types.test.ts(209,11): Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts: Type 'Store<string>' is not assignable to type 'Store<number>'.
+types.test.ts: Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts: Type 'Event<string>' is not assignable to type 'Event<number>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(234,13): Type 'Event<string>' is not assignable to type 'Event<number>'.
-types.test.ts(278,17): Argument of type 'Effect<number, string, any>' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
+types.test.ts: Type 'Event<string>' is not assignable to type 'Event<number>'.
+types.test.ts: Argument of type 'Effect<number, string, any>' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
   Types of parameters 'payload' and 'params' are incompatible.
     Type '{}' is not assignable to type 'number'.
-types.test.ts(285,7): Expected 1 arguments, but got 0.
-types.test.ts(289,43): Argument of type '() => void' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
+types.test.ts: Expected 1 arguments, but got 0.
+types.test.ts: Argument of type '() => void' is not assignable to parameter of type '(params: {}) => {} | Promise<{}>'.
   Type 'void' is not assignable to type '{} | Promise<{}>'.
-types.test.ts(297,15): Type 'Effect<string, string, Error>' is not assignable to type 'Effect<number, number, Error>'.
+types.test.ts: Type 'Effect<string, string, Error>' is not assignable to type 'Effect<number, number, Error>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(312,11): Type 'Store<number>' is not assignable to type 'Store<string>'.
+types.test.ts: Type 'Store<number>' is not assignable to type 'Store<string>'.
   Type 'number' is not assignable to type 'string'.
-types.test.ts(335,13): Type 'Event<number>' is not assignable to type 'Event<string>'.
+types.test.ts: Type 'Event<number>' is not assignable to type 'Event<string>'.
   Type 'number' is not assignable to type 'string'.
-types.test.ts(341,13): Type 'Event<void>' is not assignable to type 'Event<string>'.
+types.test.ts: Type 'Event<void>' is not assignable to type 'Event<string>'.
   Type 'void' is not assignable to type 'string'.
-types.test.ts(401,11): Type 'Store<string>' is not assignable to type 'Store<number>'.
+types.test.ts: Type 'Store<string>' is not assignable to type 'Store<number>'.
   Type 'string' is not assignable to type 'number'.
-types.test.ts(483,34): Argument of type '234' is not assignable to parameter of type 'string | undefined'.
-types.test.ts(484,34): Argument of type '{ foo: boolean; }' is not assignable to parameter of type 'string'.
-types.test.ts(500,13): Argument of type '20' is not assignable to parameter of type 'string'.
-types.test.ts(504,13): Argument of type '20' is not assignable to parameter of type 'string'.
-types.test.ts(590,17): Argument of type '\\"\\"' is not assignable to parameter of type 'number'.
-types.test.ts(622,15): Type 'number' is not assignable to type 'string'.
-types.test.ts(624,24): Property 'unknownProp' does not exist on type '{ id: number; }'.
-types.test.ts(629,15): Type 'string' is not assignable to type 'number'.
-types.test.ts(636,28): Type 'number' does not satisfy the constraint 'object'.
-types.test.ts(642,20): Argument of type '1' is not assignable to parameter of type '{ a: number; } | undefined'.
-types.test.ts(644,20): Argument of type '{}' is not assignable to parameter of type '{ a: number; }'.
+types.test.ts: Argument of type '234' is not assignable to parameter of type 'string | undefined'.
+types.test.ts: Argument of type '{ foo: boolean; }' is not assignable to parameter of type 'string'.
+types.test.ts: Argument of type '20' is not assignable to parameter of type 'string'.
+types.test.ts: Argument of type '20' is not assignable to parameter of type 'string'.
+types.test.ts: Argument of type '\\"\\"' is not assignable to parameter of type 'number'.
+types.test.ts: Type 'number' is not assignable to type 'string'.
+types.test.ts: Property 'unknownProp' does not exist on type '{ id: number; }'.
+types.test.ts: Type 'string' is not assignable to type 'number'.
+types.test.ts: Type 'number' does not satisfy the constraint 'object'.
+types.test.ts: Argument of type '1' is not assignable to parameter of type '{ a: number; } | undefined'.
+types.test.ts: Argument of type '{}' is not assignable to parameter of type '{ a: number; }'.
   Property 'a' is missing in type '{}' but required in type '{ a: number; }'.
-useStoreMap.test.tsx(50,28): Tuple type 'readonly [number]' of length '1' has no element at index '1'.
-useStoreMap.test.tsx(71,11): Type '[number, \\"username\\" | \\"email\\" | \\"bio\\"]' is not assignable to type '[number, number]'.
+useStoreMap.test.tsx: Tuple type 'readonly [number]' of length '1' has no element at index '1'.
+useStoreMap.test.tsx: Type '[number, \\"username\\" | \\"email\\" | \\"bio\\"]' is not assignable to type '[number, number]'.
   Type '\\"username\\" | \\"email\\" | \\"bio\\"' is not assignable to type 'number'.
     Type '\\"username\\"' is not assignable to type 'number'.
-useStoreMap.test.tsx(83,43): Element implicitly has an 'any' type because index expression is not of type 'number'.
+useStoreMap.test.tsx: Element implicitly has an 'any' type because index expression is not of type 'number'.
 "
 `;

--- a/src/types/__tests__/run-tests.test.js
+++ b/src/types/__tests__/run-tests.test.js
@@ -18,6 +18,7 @@ test('TypeScript', async () => {
     const cleanedMessage = err.message
       .replace(/src\/types\//gm, '')
       .replace(/error TS\d+: /gm, '')
+      .replace(/\(\d+,\d+\)/gm, '')
     expect(cleanedMessage).toMatchSnapshot('rejected')
   }
 })

--- a/src/types/__tests__/run-tests.test.js
+++ b/src/types/__tests__/run-tests.test.js
@@ -9,7 +9,8 @@ import {generateReport} from '../show'
 
 jest.setTimeout(50000)
 
-test('TypeScript', async() => {
+test('TypeScript', async () => {
+  console.error('Typechecking TypeScript...')
   try {
     const data = await execa('npx', ['tsc', '-p', 'src/types'])
     expect(data).toMatchSnapshot('resolved')
@@ -21,7 +22,8 @@ test('TypeScript', async() => {
   }
 })
 
-test('Flow', async() => {
+test('Flow', async () => {
+  console.error('Typechecking Flow...')
   try {
     const data = await execa('npx', [
       'flow',

--- a/src/types/types.test.js
+++ b/src/types/types.test.js
@@ -372,11 +372,15 @@ describe('Store', () => {
     const store = createStore(0)
     const kind: kind = store.kind
     const shortName: string = store.shortName
+    const domainName: CompositeName | typeof undefined = store.domainName
+    const compositeName: CompositeName = store.compositeName
     const defaultState: number = store.defaultState
 
     const computed = store.map(() => 'hello')
     const kind1: kind = computed.kind
     const shortName1: string = computed.shortName
+    const domainName1: CompositeName | typeof undefined = computed.domainName
+    const compositeName1: CompositeName = computed.compositeName
     const defaultState1: string = computed.defaultState
   })
 

--- a/src/types/types.test.js
+++ b/src/types/types.test.js
@@ -20,6 +20,7 @@ import {
   //ComputedStore,
   //ComputedEvent,
   /*::type*/ kind,
+  /*::type*/ CompositeName,
   forward,
   launch,
   split,
@@ -187,6 +188,19 @@ describe('Event', () => {
       name: 'event name [2]'
     })
   })
+  test('#(properties)', () => {
+    const event = createEvent()
+    const kind: kind = event.kind
+    const shortName: string = event.shortName
+    const domainName: CompositeName | typeof undefined = event.domainName
+    const compositeName: CompositeName = event.compositeName
+
+    const computed = event.map(() => 'hello')
+    const kind1: kind = computed.kind
+    const shortName1: string = computed.shortName
+    const domainName1: CompositeName | typeof undefined = computed.domainName
+    const compositeName1: CompositeName = computed.compositeName
+  })
   test('#map', () => {
     const event: Event<number> = createEvent()
     const computed = event.map(() => 'foo')
@@ -240,6 +254,20 @@ describe('Effect', () => {
     const createEffect_effect5: Effect<number, string> = createEffect({
       name: 'fx 5',
     })
+  })
+
+  test('#(properties)', () => {
+    const effect = createEffect()
+    const kind: kind = effect.kind
+    const shortName: string = effect.shortName
+    const domainName: CompositeName | typeof undefined = effect.domainName
+    const compositeName: CompositeName = effect.compositeName
+
+    const computed = effect.map(() => 'hello')
+    const kind1: kind = computed.kind
+    const shortName1: string = computed.shortName
+    const domainName1: CompositeName | typeof undefined = computed.domainName
+    const compositeName1: CompositeName = computed.compositeName
   })
 
   test('#use', () => {


### PR DESCRIPTION
Fixes https://github.com/zerobias/effector/issues/165


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#165: Property "shortName" is missing on types for Event and Effect](https://issuehunt.io/repos/123197392/issues/165)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->