### PR TITLE
Update type of Event.filter

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -50,6 +50,7 @@ export interface Event<Payload> extends Unit<Payload> {
   (payload: Payload): Payload
   watch(watcher: (payload: Payload) => any): Subscription
   map<T>(fn: (payload: Payload) => T): Event<T>
+  filter<T extends Payload>(config: {fn(payload: Payload): payload is T}): Event<T>
   filter(config: {fn(payload: Payload): boolean}): Event<Payload>
   /**
    * @deprecated This form is deprecated, use `filterMap` method instead.


### PR DESCRIPTION
Refine type of payload if filter got a predicate function as a callback
```javascript
import { createEvent } from 'effector'

const event = createEvent<string | number>()

const isString = (value: any): value is string => typeof value === 'string'
const isNumber = (value: any): value is number => typeof value === 'number'

const str = event.filter({fn: isString}) // Event<string>
const num = event.filter({fn: isNumber}) // Event<number>

str.watch(value => value.slice()) // OK now
num.watch(value => value.toFixed(2)) // OK now
```