### PR TITLE
Fix createEffect TypeScript type with void parameter

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -264,11 +264,11 @@ export function createEffect<Params, Done, Fail = Error>(
   config?: {
     handler?: (params: Params) => Promise<Done> | Done
   },
-): Effect<Params, Done, Fail>
+): ((params: Params) => any) extends (params: unknown) => void ? Effect<void, Done, Fail> : Effect<Params, Done, Fail>
 export function createEffect<Params, Done, Fail = Error>(config: {
   name?: string
   handler?: (params: Params) => Promise<Done> | Done
-}): Effect<Params, Done, Fail>
+}): ((params: Params) => any) extends (params: unknown) => void ? Effect<void, Done, Fail> : Effect<Params, Done, Fail>
 
 export function createStore<State>(
   defaultState: State,


### PR DESCRIPTION
Fixes #106


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#106: createEffect doesn't resolve void Params](https://issuehunt.io/repos/123197392/issues/106)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->