### PR TITLE
Add impossibilty of forwarding parts of *Effect*

### DIFF
--- a/docs/api/effector/createEffect.md
+++ b/docs/api/effector/createEffect.md
@@ -18,6 +18,8 @@ Creates an [effect](Effect.md)
 
 ([_`Effect`_](Effect.md)): A container for async function.
 
+> **Note**: You are not supposed to [`Forward`](forward.md) parts of *Effect* (even though it consists of *Events* and *Stores*), since it's a complete entity on its own. This behavior will not be supported
+
 #### Examples
 
 Create unnamed effect


### PR DESCRIPTION
Since *Effect* has *Events* and *Stores* within it, people may assume they can *Forward* them, as they would regular *Events* and *Stores*. However, this behavior is not implied, and hence not supported.