### PR TITLE
fix .gitpod.yml: run `init` and `command` in the same terminal

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,3 @@
 tasks:
   - init: yarn
-  - command: yarn test:watch
+    command: yarn test:watch


### PR DESCRIPTION
Hello! 👋

I noticed that your `.gitpod.yml` specifies two terminals:

```yaml
tasks:
  - init: yarn
  - command: yarn test:watch
```

I think that was unintentional, and that `init` and `command` should run in the same Terminal, one after the other:

```yaml
tasks:
  - init: yarn
    command: yarn test:watch
```

(one `-` === one Terminal)