### PR TITLE
#180 fix mobile error overlay

### DIFF
--- a/website/editor/src/styles.css
+++ b/website/editor/src/styles.css
@@ -165,6 +165,7 @@ body {
     grid-column: 1 / span 1;
     grid-row: 1 / span 2;
     border-bottom: 1px solid #ffd6d6;
+    margin-top: 86px;
   }
 }
 @media (min-width: 700px) {


### PR DESCRIPTION
fixes #180
Just a tiny css tweak on the mobile media query so you can use the editor whilst you have an error being displayed;


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#180: Error overlay is on top of navigation UI on mobile](https://issuehunt.io/repos/123197392/issues/180)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->