### PR TITLE
improve typescript inference for merge method

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -267,6 +267,9 @@ export function forward<To, From extends To>(opts: {
 }): Subscription
 
 export function merge<T>(events: ReadonlyArray<Unit<T>>): Event<T>
+export function merge<T extends ReadonlyArray<Unit<any>>>(
+  events: T
+): T[number] extends Unit<infer R> ? Event<R> : never
 export function clearNode(unit: Unit<any> | Step, opts?: {deep?: boolean}): void
 export function createNode(opts: {
   node: Array<Cmd>


### PR DESCRIPTION
Add overload to handle cases with non-intersecting types
```javascript
const a = createEvent<number>()
const b = createEvent<string>()
const merged = merge([a,b])
```
**Current behaviour**: Error
```
Type 'Unit<string>' is not assignable to type 'Unit<number>'.
  Type 'string' is not assignable to type 'number'.
```
**After fix**: No error. `typeof merged = Event<string | number>`