### PR TITLE
Ts infer optional params from effect handler

### DIFF
--- a/src/types/__tests__/effector/effect.test.js
+++ b/src/types/__tests__/effector/effect.test.js
@@ -242,7 +242,7 @@ describe('optional params', () => {
       expect(typecheck).toMatchInlineSnapshot(`
         "
         --typescript--
-        Argument of type '1' is not assignable to parameter of type 'void'.
+        no errors
 
         --flow--
         no errors
@@ -257,7 +257,7 @@ describe('optional params', () => {
       expect(typecheck).toMatchInlineSnapshot(`
         "
         --typescript--
-        Argument of type '\\"really anything\\"' is not assignable to parameter of type 'void'.
+        Expected 1 arguments, but got 0.
 
 
         --flow--

--- a/src/types/__tests__/effector/effect.test.js
+++ b/src/types/__tests__/effector/effect.test.js
@@ -205,7 +205,6 @@ describe('nested effects', () => {
                     Types of parameters 'payload' and 'payload' are incompatible.
                       Type '{ params: string; result: string; }' is not assignable to type '{ params: number; result: number; }'.
 
-
         --flow--
         Cannot assign 'createEffect(...)' to 'parentEffect'
           const parentEffect: Effect<number, number> = createEffect(
@@ -232,4 +231,39 @@ describe('nested effects', () => {
     })
   })
   test('with use', () => {})
+})
+describe('optional params', () => {
+  describe('inference of optional argument type from handler type', () => {
+    it('should allow calls with and w/o arguments', () => {
+      const handler = (params = 0) => params
+      const effect = createEffect({handler})
+      effect(1)
+      effect()
+      expect(typecheck).toMatchInlineSnapshot(`
+        "
+        --typescript--
+        Argument of type '1' is not assignable to parameter of type 'void'.
+
+        --flow--
+        no errors
+        "
+      `)
+    })
+    it('should allow calls with and w/o arguments in case of `params?: any`', () => {
+      const handler = (params?: any) => params
+      const effect = createEffect({handler})
+      effect('really anything')
+      effect()
+      expect(typecheck).toMatchInlineSnapshot(`
+        "
+        --typescript--
+        Argument of type '\\"really anything\\"' is not assignable to parameter of type 'void'.
+
+
+        --flow--
+        no errors
+        "
+      `)
+    })
+  })
 })


### PR DESCRIPTION
The problem with current createEffect typescript typings is that [`FN extends () => infer Done`](https://github.com/zerobias/effector/blob/master/packages/effector/index.d.ts#L300) condition satisfies zero-or-one-arity effect handlers. Handler like `(x?: TYPE) => any` will produce `Effect<void,...>`. New test suite with updated snapshots [displays](https://github.com/zerobias/effector/commit/eef87cefab3068f73cc3ff2d2205484631d3bd47#diff-0015a2dd8aaa7b887423704ae136efeeR245) these errors.

You may see new typings proposal partially improving current situation. I added some comments to explain why it was difficult to deal with type `any`.

The last commit contains finally updated snapshots to demonstrate how proposed typings work.