### PR TITLE
Allow predicate refinements for split

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -324,7 +324,7 @@ export function createStoreObject<State>(
 export function split<S, Obj extends {[name: string]: (payload: S) => boolean}>(
   source: Unit<S>,
   cases: Obj,
-): {[K in keyof Obj]: Event<S>} & {__: Event<S>}
+): {[K in keyof Obj]: Obj[K] extends (p: any) => p is infer R ? Event<R> : Event<S>} & {__: Event<S>}
 
 export function createApi<
   S,


### PR DESCRIPTION
```typescript
const source = createEvent<string | number | null | {}>()

const events = split(source, {
    numbers: (a): a is number => typeof a === 'number',
    strings: (a): a is string => typeof a === 'string',
    not_refined: (a) => !!a,
})

// Event<number>, no error
events.numbers.map(a => a.toFixed())

// Event<string>, no error
events.strings.map(a => a.charCodeAt(0))

// still fails, object is possibly null
events.not_refined.map(a => a.toString())
```