### PR TITLE
introduce `name` property in sample parameters list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ submitForm('alice') // ~> searchUser('alice')
 [Type inference](https://github.com/zerobias/effector/blob/master/src/types/__tests__/effector/guard.test.js)
 [Implementation tests](https://github.com/zerobias/effector/blob/master/src/effector/__tests__/guard.test.js)
 
+- Introduce `name` property in `sample` parameters list:
+
+```js
+import {createStore, sample} from 'effector'
+
+const foo = createStore(null)
+
+const sampled = sample({
+  source: foo,
+  name: 'sampled foo',
+})
+
+console.log(sampled.shortName) // 'sampled foo'
+```
+
 ## effector 20.3.2
 
 - Allow typescript to refine type with `split` method ([PR](https://github.com/zerobias/effector/pull/215))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,10 @@ submitForm('alice') // ~> searchUser('alice')
 [Type inference](https://github.com/zerobias/effector/blob/master/src/types/__tests__/effector/guard.test.js)
 [Implementation tests](https://github.com/zerobias/effector/blob/master/src/effector/__tests__/guard.test.js)
 
-- Introduce `name` property in `sample` parameters list:
+- Introduce `name` property in `sample` parameters list
+
+Each basic entity in Effector (event/effect/store/domain) may have a name. You now can name sampled entities in the same
+manner as basic ones.
 
 ```js
 import {createStore, sample} from 'effector'


### PR DESCRIPTION
Mention `name` property of `sample` parameters list right below the `guard` feature introduction.