### PR TITLE
Better `forward` typings (TS)

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -284,7 +284,7 @@ export function forward<T>(opts: {
   from: Unit<T & {}>;
   to: Unit<T>
 }): Subscription
-// Do not remove the second signature to avoid breaking changes!
+// Do not remove the signature below to avoid breaking change!
 export function forward<To, From extends To>(opts: {
   from: Unit<From>
   to: Unit<To>

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -261,6 +261,11 @@ export const step: {
   run(data: {fn: (data: any, scope: {[field: string]: any}) => any}): Run
 }
 
+// Allow `* -> void` forwarding (e.g. `string -> void`).
+export function forward(opts: {
+  from: Unit<any>
+  to: Unit<void>
+}): Subscription
 export function forward<T>(opts: {
   /**
   * By default TS picks "best common type" `T` between `from` and `to` arguments.

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -260,7 +260,26 @@ export const step: {
   update(data: {store: StateRef}): Update
   run(data: {fn: (data: any, scope: {[field: string]: any}) => any}): Run
 }
-export function forward<T>(opts: {from: Unit<T>; to: Unit<T>}): Subscription
+
+export function forward<T>(opts: {
+  /**
+  * By default TS picks "best common type" `T` between `from` and `to` arguments.
+  * This lets us forward from `string | number` to `string` for instance, and
+  * this is wrong.
+  * 
+  * Fortunately we have a way to disable such behavior. By adding `& {}` to some
+  * generic type we tell TS "do not try to infer this generic type from
+  * corresponding argument type". 
+  * 
+  * Generic `T` won't be inferred from `from` any more. Forwarding from "less
+  * strict" to "more strict" will produce an error as expected.
+  * 
+  * @see https://www.typescriptlang.org/docs/handbook/type-inference.html#best-common-type
+  */
+  from: Unit<T & {}>;
+  to: Unit<T>
+}): Subscription
+// Do not remove the second signature to avoid breaking changes!
 export function forward<To, From extends To>(opts: {
   from: Unit<From>
   to: Unit<To>

--- a/src/types/__tests__/effector/forward.test.js
+++ b/src/types/__tests__/effector/forward.test.js
@@ -128,7 +128,10 @@ describe('forward with subtyping', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      no errors
+      Type 'Event<string | number>' is not assignable to type 'Unit<string>'.
+        Types of property '__' are incompatible.
+          Type 'string | number' is not assignable to type 'string'.
+            Type 'number' is not assignable to type 'string'.
 
       --flow--
       Cannot call 'forward' with object literal bound to 'opts'
@@ -170,10 +173,11 @@ describe('forward with subtyping', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      Type 'Event<string | number>' is not assignable to type 'Unit<string>'.
+      Type 'Event<string | number>' is not assignable to type 'Unit<string & {}>'.
         Types of property '__' are incompatible.
-          Type 'string | number' is not assignable to type 'string'.
-            Type 'number' is not assignable to type 'string'.
+          Type 'string | number' is not assignable to type 'string & {}'.
+            Type 'number' is not assignable to type 'string & {}'.
+              Type 'number' is not assignable to type 'string'.
 
       --flow--
       Cannot call 'forward' with object literal bound to 'opts'

--- a/src/types/__tests__/effector/forward.test.js
+++ b/src/types/__tests__/effector/forward.test.js
@@ -213,7 +213,6 @@ describe('forward with subtyping', () => {
       Type 'string | number' does not satisfy the constraint 'string'.
         Type 'number' is not assignable to type 'string'.
 
-
       --flow--
       Cannot call 'forward' with object literal bound to 'opts'
         forward<string, string | number>({to: str, from: strOrNum})
@@ -225,6 +224,37 @@ describe('forward with subtyping', () => {
                 [2] ^^^^^^
             interface CovariantUnit<+T> {
                                  [3] ^
+      "
+    `)
+  })
+})
+
+describe('better inference experience', () => {
+  it('should forward from `Unit<*>` to `Unit<void>`', () => {
+    const from = createEvent<string>()
+    const to = createEvent<void>()
+
+    forward({from, to})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      Type 'Event<string>' is not assignable to type 'Unit<void>'.
+        Types of property '__' are incompatible.
+          Type 'string' is not assignable to type 'void'.
+
+
+      --flow--
+      Cannot call 'forward' with object literal bound to 'opts'
+        forward({from, to})
+                ^^^^^^^^^^
+        undefined [1] is incompatible with string [2] in type argument 'T' [3] of property 'to'
+            const to = createEvent<void>()
+                               [1] ^^^^
+            const from = createEvent<string>()
+                                 [2] ^^^^^^
+            export interface Unit<T> extends CovariantUnit<T>, ContravariantUnit<T> {
+                              [3] ^
       "
     `)
   })

--- a/src/types/__tests__/effector/forward.test.js
+++ b/src/types/__tests__/effector/forward.test.js
@@ -175,7 +175,6 @@ describe('forward with subtyping', () => {
           Type 'string | number' is not assignable to type 'string'.
             Type 'number' is not assignable to type 'string'.
 
-
       --flow--
       Cannot call 'forward' with object literal bound to 'opts'
         forward<string>({from: strOrNum, to: str})
@@ -184,6 +183,41 @@ describe('forward with subtyping', () => {
             const strOrNum: Event<string | number> = createEvent()
                                        [1] ^^^^^^
             forward<string>({from: strOrNum, to: str})
+                [2] ^^^^^^
+            interface CovariantUnit<+T> {
+                                 [3] ^
+      "
+    `)
+  })
+  it('generics `to` and `from` (should pass)', () => {
+    forward<string | number, string>({to: strOrNum, from: str})
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      no errors
+      "
+    `)
+  })
+  it('generics `to` and `from` (should fail on providing generics)', () => {
+    forward<string, string | number>({to: str, from: strOrNum})
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      Type 'string | number' does not satisfy the constraint 'string'.
+        Type 'number' is not assignable to type 'string'.
+
+
+      --flow--
+      Cannot call 'forward' with object literal bound to 'opts'
+        forward<string, string | number>({to: str, from: strOrNum})
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
+        number [1] is incompatible with string [2] in type argument 'T' [3] of property 'from'
+            const strOrNum: Event<string | number> = createEvent()
+                                       [1] ^^^^^^
+            forward<string, string | number>({to: str, from: strOrNum})
                 [2] ^^^^^^
             interface CovariantUnit<+T> {
                                  [3] ^

--- a/src/types/__tests__/effector/forward.test.js
+++ b/src/types/__tests__/effector/forward.test.js
@@ -213,6 +213,7 @@ describe('forward with subtyping', () => {
       Type 'string | number' does not satisfy the constraint 'string'.
         Type 'number' is not assignable to type 'string'.
 
+
       --flow--
       Cannot call 'forward' with object literal bound to 'opts'
         forward<string, string | number>({to: str, from: strOrNum})
@@ -239,10 +240,7 @@ describe('better inference experience', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      Type 'Event<string>' is not assignable to type 'Unit<void>'.
-        Types of property '__' are incompatible.
-          Type 'string' is not assignable to type 'void'.
-
+      no errors
 
       --flow--
       Cannot call 'forward' with object literal bound to 'opts'


### PR DESCRIPTION
Fixed wrong `forward` typings behavior, when forwarding FROM "less strict" type TO "more strict" type throws no errors.