### PR TITLE
[TS] typings fix for `combine`, accepting list of stores

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="symbol-observable" />
 
+/**
+ * This tuple type is intended for use as a generic constraint to infer concrete
+ * tuple type of ANY length.
+ *
+ * @see https://github.com/krzkaczor/ts-essentials/blob/a4c2485bc3f37843267820ec552aa662251767bc/lib/types.ts#L169
+ */
+type Tuple<T = unknown> = [T] | T[]
+
 export const version: string
 
 export type kind = 'store' | 'event' | 'effect' | 'domain'
@@ -515,10 +523,19 @@ export function guard<A>(config: {
   target: Unit<A>
 }): Unit<A>
 
+export function combine<State extends Tuple>(
+  shape: State,
+): Store<{[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]}>
 export function combine<State>(
   shape: State,
 ): Store<{[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]}>
 export function combine<A, R>(a: Store<A>, fn: (a: A) => R): Store<R>
+export function combine<State extends Tuple, R>(
+  shape: State,
+  fn: (
+    shape: {[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]},
+  ) => R,
+): Store<R>
 export function combine<State, R>(
   shape: State,
   fn: (

--- a/src/types/__tests__/effector/combine.test.js
+++ b/src/types/__tests__/effector/combine.test.js
@@ -45,10 +45,7 @@ describe('combine cases (should pass)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      Property 'toFixed' does not exist on type 'Store<number> | Store<string>'.
-        Property 'toFixed' does not exist on type 'Store<number>'.
-      Property 'charAt' does not exist on type 'Store<number> | Store<string>'.
-        Property 'charAt' does not exist on type 'Store<number>'.
+      no errors
 
       --flow--
       in the first argument: Either cannot get 'n.toFixed'
@@ -142,10 +139,7 @@ describe('combine cases (should pass)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      Property 'toFixed' does not exist on type 'Store<number> | Store<string>'.
-        Property 'toFixed' does not exist on type 'Store<number>'.
-      Property 'charAt' does not exist on type 'Store<number> | Store<string>'.
-        Property 'charAt' does not exist on type 'Store<number>'.
+      no errors
 
       --flow--
       in the first argument: Either cannot get 'n.toFixed'

--- a/src/types/__tests__/effector/combine.test.js
+++ b/src/types/__tests__/effector/combine.test.js
@@ -35,6 +35,33 @@ describe('combine cases (should pass)', () => {
       "
     `)
   })
+  test('combine([Store<number>,Store<string>])', () => {
+    const sn = createStore(0)
+    const ss = createStore('')
+    const store = combine([sn, ss]).map(([n, s]) => {
+      n.toFixed // should have method on type
+      s.charAt // should have method on type
+    })
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      Property 'toFixed' does not exist on type 'Store<number> | Store<string>'.
+        Property 'toFixed' does not exist on type 'Store<number>'.
+      Property 'charAt' does not exist on type 'Store<number> | Store<string>'.
+        Property 'charAt' does not exist on type 'Store<number>'.
+
+      --flow--
+      in the first argument: Either cannot get 'n.toFixed'
+        const store = combine([sn, ss]).map(([n, s]) => {
+                                   ^^
+        property 'toFixed' is missing in 'String' [1]. Or cannot get 'n.toFixed'
+            const ss = createStore('')
+                               [1] ^^
+            ): Store<State>
+           [2] ^^^^^^^^^^^^
+      "
+    `)
+  })
   test('combine({Color})', () => {
     const Color = createStore('#e95801')
     const store: Store<{Color: string}> = combine({Color})
@@ -102,6 +129,33 @@ describe('combine cases (should pass)', () => {
 
       --flow--
       no errors
+      "
+    `)
+  })
+  test(`combine([Store<number>,Store<string>], ([number,string]) => ...)`, () => {
+    const sn = createStore(0)
+    const ss = createStore('')
+    const store = combine([sn, ss], ([n, s]) => {
+      n.toFixed // should have method on type
+      s.charAt // should have method on type
+    })
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      Property 'toFixed' does not exist on type 'Store<number> | Store<string>'.
+        Property 'toFixed' does not exist on type 'Store<number>'.
+      Property 'charAt' does not exist on type 'Store<number> | Store<string>'.
+        Property 'charAt' does not exist on type 'Store<number>'.
+
+      --flow--
+      in the first argument: Either cannot get 'n.toFixed'
+        const store = combine([sn, ss], ([n, s]) => {
+                                   ^^
+        property 'toFixed' is missing in 'String' [1]. Or cannot get 'n.toFixed'
+            const ss = createStore('')
+                               [1] ^^
+            ): Store<State>
+           [2] ^^^^^^^^^^^^
       "
     `)
   })
@@ -418,6 +472,13 @@ describe('error inference (should fail with number -> string error)', () => {
       Type 'Store<string>' is not assignable to type 'Store<number>'.
 
       --flow--
+      'Store' [1] is not a valid argument of '$ObjMap' [2]
+        ): Store<$ObjMap<State, <S>(field: Store<S> | S) => S>>
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ): Store<State>
+           [1] ^^^^^^^^^^^^
+            ): Store<$ObjMap<State, <S>(field: Store<S> | S) => S>>
+                 [2] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       in the first argument: Either cannot assign 'combine(...)' to 'store'
         [R, G, B],
                ^
@@ -443,13 +504,6 @@ describe('error inference (should fail with number -> string error)', () => {
       Type 'Store<string>' is not assignable to type 'Store<number>'.
 
       --flow--
-      'Store' [1] is not a valid argument of '$ObjMap' [2]
-        ): Store<$ObjMap<State, <S>(field: Store<S> | S) => S>>
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            ): Store<State>
-           [1] ^^^^^^^^^^^^
-            ): Store<$ObjMap<State, <S>(field: Store<S> | S) => S>>
-                 [2] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       in the first argument: Either cannot assign 'combine(...)' to 'store'
         const store: Store<number> = combine({Color}, ({Color}) => Color)
                                               ^^^^^


### PR DESCRIPTION
Hello!

Effector 20.5.0:

```
import { combine, Store } from 'effector';

const sn = {} as Store<number>;
const ss = {} as Store<string>;

const dict = combine({ sn, ss }); // Store<{ sn: number; ss: string; }>
//                                   ^^^^^^^^^^^ That's ok! ^^^^^^^^^^^

const tuple = combine([sn, ss]); // Store<(Store<number> | Store<string>)[]>
//                                  ^^^^^^^^^^^ Looks incorrect ^^^^^^^^^^^
```

After typings fix:

```
const tuple = combine([sn, ss]); // Store<[number, string]>
//                                  ^^^^ Now that's ok too!

// As a consequence this will work after accepting the proposal
combine([sn, ss], ([n, s]) => {
  n.toExponential; // OK, has type specific method
  s.charAt; // OK, has type specific method
});
```