### PR TITLE
Sample target forwarding typings

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -8,6 +8,13 @@
  */
 type Tuple<T = unknown> = [T] | T[]
 
+/**
+ * Non inferential type parameter usage.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/14829#issuecomment-504042546
+ */
+type NoInfer<T> = [T][T extends any ? 0 : never]
+
 export const version: string
 
 export type kind = 'store' | 'event' | 'effect' | 'domain'
@@ -452,12 +459,12 @@ export function sample<A, B, C>(
 export function sample<A, B, C>(config: {
   source: Unit<A>
   clock: Unit<B>
-  fn: (source: A, clock: B) => C
+  fn: (source: A, clock: B) => NoInfer<C>
   target: Unit<C>
   greedy?: boolean
 }): Unit<C>
 export function sample<A>(config: {
-  source: Unit<A>
+  source: Unit<NoInfer<A>>
   clock: Unit<any>
   target: Unit<A>
   greedy?: boolean

--- a/src/types/__tests__/effector/sample.test.js
+++ b/src/types/__tests__/effector/sample.test.js
@@ -331,29 +331,6 @@ describe('sample(Store<T>):Store<T>', () => {
   })
 })
 
-test('edge case (should fail)', () => {
-  const event1 = createEvent()
-  const event2 = createEvent<{prop: string}>()
-
-  const store = createStore('value')
-
-  sample({
-    source: store,
-    clock: event1,
-    fn: () => ({}),
-    target: event2,
-  })
-  expect(typecheck).toMatchInlineSnapshot(`
-    "
-    --typescript--
-    no errors
-
-    --flow--
-    no errors
-    "
-  `)
-})
-
 describe('`target` forwarding', () => {
   it('should pass when a target receives a more strict (or equal) value type from a source', () => {
     const source = createStore({a: '', b: ''})

--- a/src/types/__tests__/effector/sample.test.js
+++ b/src/types/__tests__/effector/sample.test.js
@@ -353,3 +353,134 @@ test('edge case (should fail)', () => {
     "
   `)
 })
+
+describe('`target` forwarding', () => {
+  it('should pass when a target receives a more strict (or equal) value type from a source', () => {
+    const source = createStore({a: '', b: ''})
+    const clock = createEvent()
+    const target = createEvent<{a: string}>()
+
+    sample({source, clock, target})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      no errors
+      "
+    `)
+  })
+
+  it('should pass when a target receives a more strict (or equal) value type from a mapping fn', () => {
+    const source = createStore(null)
+    const clock = createEvent()
+    const fn = () => ({a: '', b: ''})
+    const target = createEvent<{a: string}>()
+
+    sample({source, clock, fn, target})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      no errors
+      "
+    `)
+  })
+
+  it('should fail when a target receives a more loose value type from a source', () => {
+    const source = createStore({a: ''})
+    const clock = createEvent()
+    const target = createEvent<{a: string, b: string}>()
+
+    sample({source, clock, target})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      Cannot call 'sample' with object literal bound to 'config'
+        sample({source, clock, target})
+               ^^^^^^^^^^^^^^^^^^^^^^^
+        property 'b' is missing in object literal [1] but exists in object type [2] in type argument 'T' [3] of property 'target'
+            const source = createStore({a: ''})
+                                   [1] ^^^^^^^
+            const target = createEvent<{a: string, b: string}>()
+                                   [2] ^^^^^^^^^^^^^^^^^^^^^^
+            export interface Unit<T> extends CovariantUnit<T>, ContravariantUnit<T> {
+                              [3] ^
+      "
+    `)
+  })
+
+  it('should fail when a target receives a more loose value type from a mapping fn', () => {
+    const source = createStore(null)
+    const clock = createEvent()
+    const fn = () => ({a: ''})
+    const target = createEvent<{a: string, b: string}>()
+
+    sample({source, clock, fn, target})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      Cannot call 'sample' with object literal bound to 'config'
+        sample({source, clock, fn, target})
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        property 'b' is missing in object literal [1] but exists in object type [2] in type argument 'T' [3] of property 'target'
+            const fn = () => ({a: ''})
+                          [1] ^^^^^^^
+            const target = createEvent<{a: string, b: string}>()
+                                   [2] ^^^^^^^^^^^^^^^^^^^^^^
+            export interface Unit<T> extends CovariantUnit<T>, ContravariantUnit<T> {
+                              [3] ^
+      "
+    `)
+  })
+
+  it('should fail when a target receives a more loose value type from a source (edge case for {} type)', () => {
+    const source = createStore({})
+    const clock = createEvent()
+    const target = createEvent<{a: string, b: string}>()
+
+    sample({source, clock, target})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      no errors
+      "
+    `)
+  })
+
+  it('should fail when a target receives a more loose value type from a mapping fn (edge case for {} type)', () => {
+    const source = createStore(null)
+    const clock = createEvent()
+    const fn = () => ({})
+    const target = createEvent<{a: string, b: string}>()
+
+    sample({source, clock, fn, target})
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      no errors
+
+      --flow--
+      no errors
+      "
+    `)
+  })
+})

--- a/src/types/__tests__/effector/sample.test.js
+++ b/src/types/__tests__/effector/sample.test.js
@@ -313,7 +313,6 @@ describe('sample(Store<T>):Store<T>', () => {
         --typescript--
         Type 'Event<string>' is not assignable to type 'Event<number>'.
 
-
         --flow--
         Cannot assign 'sample(...)' to 'sample_s_edge_incorrect'
           const sample_s_edge_incorrect: Event<number> = sample(a, clock)
@@ -379,7 +378,10 @@ describe('`target` forwarding', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      no errors
+      No overload matches this call.
+        The last overload gave the following error.
+          Type 'Store<{ a: string; }>' is not assignable to type 'Event<unknown> | Effect<unknown, any, any>'.
+            Type 'Store<{ a: string; }>' is missing the following properties from type 'Event<unknown>': filter, filterMap, prepend, getType
 
       --flow--
       Cannot call 'sample' with object literal bound to 'config'
@@ -407,7 +409,10 @@ describe('`target` forwarding', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      no errors
+      No overload matches this call.
+        The last overload gave the following error.
+          Type 'Store<null>' is not assignable to type 'Event<unknown> | Effect<unknown, any, any>'.
+            Type 'Store<null>' is missing the following properties from type 'Event<unknown>': filter, filterMap, prepend, getType
 
       --flow--
       Cannot call 'sample' with object literal bound to 'config'
@@ -434,7 +439,10 @@ describe('`target` forwarding', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      no errors
+      No overload matches this call.
+        The last overload gave the following error.
+          Type 'Store<{}>' is not assignable to type 'Event<unknown> | Effect<unknown, any, any>'.
+            Type 'Store<{}>' is missing the following properties from type 'Event<unknown>': filter, filterMap, prepend, getType
 
       --flow--
       no errors
@@ -453,7 +461,11 @@ describe('`target` forwarding', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      no errors
+      No overload matches this call.
+        The last overload gave the following error.
+          Type 'Store<null>' is not assignable to type 'Event<unknown> | Effect<unknown, any, any>'.
+            Type 'Store<null>' is not assignable to type 'Event<unknown>'.
+
 
       --flow--
       no errors


### PR DESCRIPTION
+ test suit for `sample` cases using `target` forwarding
+ add NoInfer type hint to `sample` overloads using `target`

This will fix #247 