### PR TITLE
Improve useStoreMap typings

### DIFF
--- a/packages/effector-react/index.d.ts
+++ b/packages/effector-react/index.d.ts
@@ -25,7 +25,7 @@ export function useStore<State>(store: Store<State>): State
 export function useStoreMap<
   State,
   Result,
-  Keys extends ReadonlyArray<any> | any[]
+  Keys extends [any] | ReadonlyArray<any> | any[]
 >(opts: {
   readonly store: Store<State>
   readonly keys: Keys

--- a/src/types/__tests__/effector-react/useStoreMap.test.tsx
+++ b/src/types/__tests__/effector-react/useStoreMap.test.tsx
@@ -103,7 +103,7 @@ describe('useStoreMap', () => {
       `)
     })
   })
-  it('unable to infer tuple type without `as`', () => {
+  it('can infer tuple type without `as`', () => {
     const UserProperty = ({id, field}: Props) => {
       const value = useStoreMap({
         store: users,
@@ -115,7 +115,7 @@ describe('useStoreMap', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      Element implicitly has an 'any' type because index expression is not of type 'number'.
+      no errors
       "
     `)
   })


### PR DESCRIPTION
This uses tuple hack we already used for `combine` to improve inference for array of keys