### PR TITLE
[Typings] Workaround for typescript issue 35162

### DIFF
--- a/src/types/__tests__/effector/sample.test.js
+++ b/src/types/__tests__/effector/sample.test.js
@@ -23,6 +23,11 @@ test('event by event', () => {
     "
     --typescript--
     Type 'Event<number>' is not assignable to type 'Event<string>'.
+      Types of property 'watch' are incompatible.
+        Type '(watcher: (payload: number) => any) => Subscription' is not assignable to type '(watcher: (payload: string) => any) => Subscription'.
+          Types of parameters 'watcher' and 'watcher' are incompatible.
+            Types of parameters 'payload' and 'payload' are incompatible.
+              Type 'number' is not assignable to type 'string'.
 
     --flow--
     Cannot assign 'c' to 'sample_ee_check2'
@@ -871,7 +876,7 @@ describe('sample + guard (should pass)', () => {
     expect(typecheck).toMatchInlineSnapshot(`
       "
       --typescript--
-      Object is of type 'unknown'.
+      no errors
 
       --flow--
       no errors

--- a/src/types/__tests__/effector/sample.test.js
+++ b/src/types/__tests__/effector/sample.test.js
@@ -7,6 +7,7 @@ import {
   sample,
   Store,
   Event,
+  guard,
 } from 'effector'
 
 const typecheck = '{global}'
@@ -849,6 +850,31 @@ describe('sample with implicit combine', () => {
         [1] ^^^^^^
             source: Store<A>,
                 [2] ^^^^^^^^
+      "
+    `)
+  })
+})
+
+describe('sample + guard (should pass)', () => {
+  test("directly assign `guard` invocation to `sample`'s `clock` argument without losing inference in `sample`'s `fn`", () => {
+    const source = createStore(0)
+    const clock = createEvent<number>()
+
+    sample({
+      source,
+      clock: guard(clock, {
+        filter: clock => clock > 0,
+      }),
+      fn: (source, clock) => source + clock,
+    })
+
+    expect(typecheck).toMatchInlineSnapshot(`
+      "
+      --typescript--
+      Object is of type 'unknown'.
+
+      --flow--
+      no errors
       "
     `)
   })


### PR DESCRIPTION
Workaround for https://github.com/microsoft/TypeScript/issues/35162 (tharks to @artalar for help)

Now we can directly assign `guard` invocation to `sample`'s `clock` argument without losing inference in `sample`'s `fn`

```ts
import {sample, guard, createStore, createEvent} from 'effector'

const source = createStore(100)
const clock = createEvent<number>()

sample({
  source,
  clock: guard(clock, {
    filter: clock => clock > 0,
  }),
  fn: (source, clock) => source + clock, // clock is of type `number` now (previously inferred as `unknown`)
})
```