### PR TITLE
fix links in repl

### DIFF
--- a/website/editor/src/index.html
+++ b/website/editor/src/index.html
@@ -101,7 +101,7 @@
               <ul class="nav-site nav-site-internal">
                 <li class="">
                   <a
-                    href="https://effector.now.sh/introduction/installation"
+                    href="https://effector.now.sh/docs/introduction/installation"
                     target="_self"
                   >
                     Docs
@@ -109,7 +109,7 @@
                 </li>
                 <li class="">
                   <a
-                    href="https://effector.now.sh/api/effector/effector"
+                    href="https://effector.now.sh/docs/api/effector/effector"
                     target="_self"
                     >API</a
                   >


### PR DESCRIPTION
On website for docs, api was edited links. On REPL not. Now fixed 