### PR TITLE
created option [fn] like cb

### DIFF
--- a/packages/effector-dom/index.d.ts
+++ b/packages/effector-dom/index.d.ts
@@ -127,6 +127,21 @@ export function list<
 ): void
 export function list<T, K extends keyof T>(
   {
+    fn,
+    key,
+    source,
+    reverse,
+    fields,
+  }: {
+    source: Store<T[]>
+    fn: (opts: {store: Store<T>; key: T[K]; signal: Signal}) => void,
+    key: T[K] extends string | number | symbol ? K : never
+    reverse?: boolean
+    fields?: string[]
+  },
+): void
+export function list<T, K extends keyof T>(
+  {
     key,
     source,
     reverse,

--- a/src/dom/__tests__/index.test.ts
+++ b/src/dom/__tests__/index.test.ts
@@ -336,6 +336,28 @@ describe('list', () => {
       )
     })
   })
+  it('create list from [fn] option', async () => {
+    const [s1] = await exec(async () => {
+      const users = createStore([
+        {name: 'alice', id: 1},
+        {name: 'bob', id: 2},
+      ])
+
+      using(el, () => {
+        list({
+          source: users,
+          key: 'id',
+          fn: ({store}) => {
+            h('li', {text: store.map(v => v.name)})
+          }
+        })
+      })
+      await act()
+    })
+    expect(s1).toMatchInlineSnapshot(
+      `"<li>alice</li><li>bob</li>"`
+    )
+  })
   it.skip('insert its items before sibling nodes', async () => {
     const [s1, s2] = await exec(async () => {
       const addUser = createEvent<string>()

--- a/src/dom/render/list.ts
+++ b/src/dom/render/list.ts
@@ -20,6 +20,7 @@ import {remap} from '../storeField'
 import {setRightSibling, setLeftSibling, makeSiblings} from './locality'
 import {findNearestVisibleNode} from './nearestNode'
 import {document} from './documentResolver'
+import {h} from './h'
 
 type ListContext = {
   parentNode: DOMElement
@@ -104,7 +105,24 @@ export function list<T, K extends keyof T>(
   },
   cb: (opts: {store: Store<T>; key: T[K]; signal: Signal}) => void,
 ): void
-export function list<T>(opts, cb: (opts: any) => void) {
+export function list<T, K extends keyof T>(
+  {
+    source,
+    fn,
+    key,
+    reverse,
+    fields,
+  }: {
+    source: Store<T[]>
+    fn: (opts: {store: Store<T>; key: T[K]; signal: Signal}) => void,
+    key: T[K] extends string | number | symbol ? K : never
+    reverse?: boolean
+    fields?: string[]
+  },
+): void
+export function list<T>(opts, cb = (opts: any) => {}) {
+  cb = opts.fn ? opts.fn : cb
+
   let source
   let reverse = false
   let getID: (item: T, i: number) => string | number | symbol


### PR DESCRIPTION
Some else way to render items from `list` function. effector like the way (sample, guard)

```js
const $users = createStore([
  {name: 'Alice', id: 1},
  {name: 'Bob', id: 2}
])

list({
  source: $users,
  key: 'id',
  fn: ({store}) => {
    h('span', {
        text: store.map(({name}) => name)
    })
  }
})
```