### PR TITLE
Add support for trigger[] in store.on

### DIFF
--- a/docs/api/effector/Store.md
+++ b/docs/api/effector/Store.md
@@ -123,7 +123,6 @@ $store.on([triggerA, triggerB, ...], handler)
 
 - When `triggerA` or `triggerB` is triggered, call `handler` with payload of the `triggerA` or `triggerB` and data of `$store`
 - Next update `$store` with result of `handler()` call and trigger all subscribers
-- All triggers merged with [_merge_](merge.md)
 - Any count of triggers can be passed to `triggers`
 
 #### Arguments
@@ -158,6 +157,9 @@ changedA(2)
 
 changedB(2)
 // => updated 4
+
+// You can unsubscribe from any trigger
+store.off(changedA)
 ```
 
 #### Unsubscribe example
@@ -169,7 +171,7 @@ const store = createStore(0)
 const changedA = createEvent()
 const changedB = createEvent()
 
-// If you want to unsubscribe later, better to manually merge
+// If you want to unsubscribe from all triggers simultaneously, better to manually merge
 const changed = merge([changedA, changedB])
 
 store.on(changed, (state, params) => state + params)

--- a/docs/api/effector/Store.md
+++ b/docs/api/effector/Store.md
@@ -111,6 +111,76 @@ changed(2)
 
 <hr />
 
+### `on(triggers[], handler)`
+
+Updates state when any from `triggers` is triggered by using `handler`.
+
+#### Formulae
+
+```ts
+$store.on([triggerA, triggerB, ...], handler)
+```
+
+- When `triggerA` or `triggerB` is triggered, call `handler` with payload of the `triggerA` or `triggerB` and data of `$store`
+- Next update `$store` with result of `handler()` call and trigger all subscribers
+- All triggers merged with [_merge_](merge.md)
+- Any count of triggers can be passed to `triggers`
+
+#### Arguments
+
+1. `triggers` array of [_Event_](Event.md), [_Effect_](Effect.md) or [_Store_](Store.md)
+2. `handler` (_Function_): Reducer function that receives `state` and `params` and returns a new state, [should be **pure**](../../glossary.md#pureness).
+   A store cannot hold an `undefined` value. If a reducer function returns `undefined`, the store will not be updated.
+   - `state`: Current state of store
+   - `payload`: Value passed to event/effect call, or source if it passed as trigger
+
+#### Returns
+
+[_Store_](Store.md): Current store
+
+#### Example
+
+```js try
+import {createEvent, createStore} from 'effector'
+
+const store = createStore(0)
+const changedA = createEvent()
+const changedB = createEvent()
+
+store.on([changedA, changedB], (state, params) => state + params)
+
+store.watch(value => {
+  console.log('updated', value)
+})
+
+changedA(2)
+// => updated 2
+
+changedB(2)
+// => updated 4
+```
+
+#### Unsubscribe example
+
+```js try
+import {createEvent, createStore} from 'effector'
+
+const store = createStore(0)
+const changedA = createEvent()
+const changedB = createEvent()
+
+// If you want to unsubscribe later, better to manually merge
+const changed = merge([changedA, changedB])
+
+store.on(changed, (state, params) => state + params)
+
+store.off(changed)
+```
+
+[Try it](https://share.effector.dev/bzdoyLHm)
+
+<hr />
+
 ### `watch(watcher)`
 
 Call `watcher` function each time when store is updated. <br/>

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -16,9 +16,11 @@ type Tuple<T = unknown> = [T] | T[]
 type NoInfer<T> = [T][T extends any ? 0 : never]
 
 // Type for extention purpose. Represents combinable sample source.
-export type Combinable = { [key: string]: Store<any> } | Tuple<Store<any>>
+export type Combinable = {[key: string]: Store<any>} | Tuple<Store<any>>
 // Helper type, which unwraps combinable sample source value.
-export type GetCombinedValue<T> = {[K in keyof T]: T[K] extends Store<infer U> ? U : never}
+export type GetCombinedValue<T> = {
+  [K in keyof T]: T[K] extends Store<infer U> ? U : never
+}
 
 export const version: string
 
@@ -147,6 +149,10 @@ export interface Store<State> extends Unit<State> {
     trigger: Unit<E>,
     handler: (state: State, payload: E) => State | void,
   ): this
+  on<E>(
+    triggers: Unit<E>[],
+    handler: (state: State, payload: E) => State | void,
+  ): this
   off(trigger: Unit<any>): this
   subscribe(listener: (state: State) => any): Subscription
   updates: Event<State>
@@ -189,7 +195,10 @@ export class Domain implements Unit<any> {
   event<Payload = void>(name?: string): Event<Payload>
   event<Payload = void>(config: {name?: string; sid?: string}): Event<Payload>
   createEvent<Payload = void>(name?: string): Event<Payload>
-  createEvent<Payload = void>(config: {name?: string; sid?: string}): Event<Payload>
+  createEvent<Payload = void>(config: {
+    name?: string
+    sid?: string
+  }): Event<Payload>
   effect<Params, Done, Fail = Error>(
     name?: string,
     config?: {
@@ -326,7 +335,10 @@ export function forward<T>(opts: {
   from: Unit<T & {}>
   to: Unit<T> | ReadonlyArray<Unit<T>>
 }): Subscription
-export function forward(opts: {from: Unit<any>; to: ReadonlyArray<Unit<void>>}): Subscription
+export function forward(opts: {
+  from: Unit<any>
+  to: ReadonlyArray<Unit<void>>
+}): Subscription
 export function forward(opts: {
   from: ReadonlyArray<Unit<any>>
   to: ReadonlyArray<Unit<void>>
@@ -394,8 +406,8 @@ export function createEffect<FN extends Function>(config: {
   ? Effect<
       Args['length'] extends 0 // does handler accept 0 arguments?
         ? void // works since TS v3.3.3
-        : 0 | 1 extends Args['length'] // is the first argument optional?
-        ? /**
+        : 0 | 1 extends Args['length']  // is the first argument optional?
+          /**
            * Applying `infer` to a variadic arguments here we'll get `Args` of
            * shape `[T]` or `[T?]`, where T(?) is a type of handler `params`.
            * In case T is optional we get `T | undefined` back from `Args[0]`.
@@ -408,7 +420,7 @@ export function createEffect<FN extends Function>(config: {
            * other type (`any | undefined | void` becomes just `any`). And we
            * have similar situation also with the `unknown` type.
            */
-          Args[0] | void
+        ? Args[0] | void
         : Args[0],
       Done extends Promise<infer Async> ? Async : Done,
       Error
@@ -654,7 +666,7 @@ export function guard<A>(
 ): Unit<A>
 export function guard<A>(config: {
   source: Unit<A>
-  filter: ((value: A) => boolean)
+  filter: (value: A) => boolean
   target: Unit<void>
 }): Unit<void>
 export function guard(config: {
@@ -683,26 +695,46 @@ export function guard<A>(config: {
 
 type StoreShape = Store<any> | Combinable
 type GetShapeValue<T> = T extends Store<infer S> ? S : GetCombinedValue<T>
-type FXParams<FX extends Effect<any, any, any>> = FX extends Effect<infer P, any, any> ? P : never
-type FXResult<FX extends Effect<any, any, any>> = FX extends Effect<any, infer D, any> ? D : never
-type FXError<FX extends Effect<any, any, any>> = FX extends Effect<any, any, infer E> ? E : never
+type FXParams<FX extends Effect<any, any, any>> = FX extends Effect<
+  infer P,
+  any,
+  any
+>
+  ? P
+  : never
+type FXResult<FX extends Effect<any, any, any>> = FX extends Effect<
+  any,
+  infer D,
+  any
+>
+  ? D
+  : never
+type FXError<FX extends Effect<any, any, any>> = FX extends Effect<
+  any,
+  any,
+  infer E
+>
+  ? E
+  : never
 
-export function attach<Params, States extends StoreShape, FX extends Effect<any, any, any>>(
-  config: {
-    source: States
-    effect: FX
-    mapParams: (params: Params, states: GetShapeValue<States>) => FXParams<FX>
-  }
-): Effect<Params, FXResult<FX>, FXError<FX>>
-export function attach<Params, FX extends Effect<any, any, any>>(
-  config: {
-    effect: FX
-    mapParams: (params: Params) => FXParams<FX>
-  }
-): Effect<Params, FXResult<FX>, FXError<FX>>
+export function attach<
+  Params,
+  States extends StoreShape,
+  FX extends Effect<any, any, any>
+>(config: {
+  source: States
+  effect: FX
+  mapParams: (params: Params, states: GetShapeValue<States>) => FXParams<FX>
+}): Effect<Params, FXResult<FX>, FXError<FX>>
+export function attach<Params, FX extends Effect<any, any, any>>(config: {
+  effect: FX
+  mapParams: (params: Params) => FXParams<FX>
+}): Effect<Params, FXResult<FX>, FXError<FX>>
 
 export function withRegion(unit: Unit<any> | Step, cb: () => void): void
-export function combine<T extends Store<any>>(store: T): T extends Store<infer R> ? Store<[R]> : never
+export function combine<T extends Store<any>>(
+  store: T,
+): T extends Store<infer R> ? Store<[R]> : never
 export function combine<State extends Tuple>(
   shape: State,
 ): Store<{[K in keyof State]: State[K] extends Store<infer U> ? U : State[K]}>
@@ -817,4 +849,6 @@ export function combine<A, B, C, D, E, F, G, H, I, J, K, R>(
   k: Store<K>,
   fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K) => R,
 ): Store<R>
-export function combine<T extends Tuple<Store<any>>>(...stores: T): Store<{[K in keyof T]: T[K] extends Store<infer U> ? U : T[K]}>
+export function combine<T extends Tuple<Store<any>>>(
+  ...stores: T
+): Store<{[K in keyof T]: T[K] extends Store<infer U> ? U : T[K]}>

--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -146,11 +146,11 @@ export interface Store<State> extends Unit<State> {
   map<T>(fn: (state: State, lastState?: T) => T): Store<T>
   map<T>(fn: (state: State, lastState: T) => T, firstState: T): Store<T>
   on<E>(
-    trigger: Unit<E>,
+    triggers: Unit<E>[],
     handler: (state: State, payload: E) => State | void,
   ): this
   on<E>(
-    triggers: Unit<E>[],
+    trigger: Unit<E>,
     handler: (state: State, payload: E) => State | void,
   ): this
   off(trigger: Unit<any>): this

--- a/packages/effector/index.js.flow
+++ b/packages/effector/index.js.flow
@@ -118,6 +118,10 @@ declare export class Store<State> implements Unit<State> {
   map<T>(fn: (state: State, lastState?: T) => T, _: void): Store<T>;
   map<T>(fn: (state: State, lastState: T) => T, firstState: T): Store<T>;
   on<E>(
+    triggers: Unit<E>[],
+    handler: (state: State, payload: E) => State | void,
+  ): this;
+  on<E>(
     trigger: Unit<E>,
     handler: (state: State, payload: E) => State | void,
   ): this;

--- a/src/effector/__tests__/store/on.test.js
+++ b/src/effector/__tests__/store/on.test.js
@@ -121,3 +121,165 @@ it('replace old links', () => {
 
   expect(store.getState()).toBe('x')
 })
+
+it('supports array of events', () => {
+  const fn = jest.fn()
+  const triggerA = createEvent()
+  const triggerB = createEvent()
+
+  const b = createStore(0)
+
+  b.on([triggerA, triggerB], (b, payload) => {
+    fn({b, payload})
+    return b + 1
+  })
+
+  triggerA('lol')
+  expect(fn).toHaveBeenCalledTimes(1)
+
+  triggerB('')
+  expect(fn).toHaveBeenCalledTimes(2)
+  triggerA(' ')
+  expect(fn).toHaveBeenCalledTimes(3)
+
+  triggerB('long word')
+  expect(fn).toHaveBeenCalledTimes(4)
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "b": 0,
+        "payload": "lol",
+      },
+      Object {
+        "b": 1,
+        "payload": "",
+      },
+      Object {
+        "b": 2,
+        "payload": " ",
+      },
+      Object {
+        "b": 3,
+        "payload": "long word",
+      },
+    ]
+  `)
+})
+it('supports array of stores', () => {
+  const fn = jest.fn()
+  const hello = createEvent<string>()
+  const world = createEvent<string>()
+  const $clockA = createStore('hello').on(hello, (_, word) => word)
+  const $clockB = createStore('world').on(world, (_, word) => word)
+
+  const $source = createStore(['word'])
+
+  $source.on([$clockA, $clockB], (state, payload) => {
+    fn({state, payload})
+    return [...state, payload]
+  })
+
+  hello('lol')
+  expect(fn).toHaveBeenCalledTimes(1)
+
+  world('')
+  expect(fn).toHaveBeenCalledTimes(2)
+  hello(' ')
+  expect(fn).toHaveBeenCalledTimes(3)
+
+  world('long word')
+  expect(fn).toHaveBeenCalledTimes(4)
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "payload": "lol",
+        "state": Array [
+          "word",
+        ],
+      },
+      Object {
+        "payload": "",
+        "state": Array [
+          "word",
+          "lol",
+        ],
+      },
+      Object {
+        "payload": " ",
+        "state": Array [
+          "word",
+          "lol",
+          "",
+        ],
+      },
+      Object {
+        "payload": "long word",
+        "state": Array [
+          "word",
+          "lol",
+          "",
+          " ",
+        ],
+      },
+    ]
+  `)
+})
+
+it('supports array of stores and events', () => {
+  const fn = jest.fn()
+  const hello = createEvent<string>()
+  const world = createEvent<string>()
+  const $clockA = createStore('hello').on(hello, (_, word) => word)
+
+  const $source = createStore(['word'])
+
+  $source.on([$clockA, world], (state, payload) => {
+    fn({state, payload})
+    return [...state, payload]
+  })
+
+  hello('lol')
+  expect(fn).toHaveBeenCalledTimes(1)
+
+  world('')
+  expect(fn).toHaveBeenCalledTimes(2)
+  hello(' ')
+  expect(fn).toHaveBeenCalledTimes(3)
+
+  world('long word')
+  expect(fn).toHaveBeenCalledTimes(4)
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "payload": "lol",
+        "state": Array [
+          "word",
+        ],
+      },
+      Object {
+        "payload": "",
+        "state": Array [
+          "word",
+          "lol",
+        ],
+      },
+      Object {
+        "payload": " ",
+        "state": Array [
+          "word",
+          "lol",
+          "",
+        ],
+      },
+      Object {
+        "payload": "long word",
+        "state": Array [
+          "word",
+          "lol",
+          "",
+          " ",
+        ],
+      },
+    ]
+  `)
+})

--- a/src/effector/createUnit.js
+++ b/src/effector/createUnit.js
@@ -17,7 +17,6 @@ import {launch} from './kernel'
 import type {Subscriber, Config} from './index.h'
 import {createName, mapName, joinName} from './naming'
 import {createLinkNode} from './forward'
-import {merge} from './merge'
 import {watchUnit} from './watch'
 import {createSubscription} from './subscription'
 import {addToRegion, readTemplate} from './region'
@@ -192,7 +191,9 @@ export function createStore<State>(
       if (!Array.isArray(events)) {
         onEvent(events, fn)
       } else {
-        onEvent(merge(events), fn)
+        for (const event of events) {
+          onEvent(event, fn)
+        }
       }
       return store
     },

--- a/src/types/__tests__/effector/store.test.js
+++ b/src/types/__tests__/effector/store.test.js
@@ -283,6 +283,56 @@ test('#on', () => {
   `)
 })
 
+test('#on triggers[]', () => {
+  const event = createEvent<string>()
+  const another = createStore('')
+  const store = createStore(0)
+
+  store.on([event, another], (state, payload) => state)
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    --typescript--
+    no errors
+
+    --flow--
+    no errors
+    "
+  `)
+})
+
+test('#on triggers[] failing', () => {
+  const event = createEvent<number>()
+  const another = createStore('')
+  const store = createStore(0)
+
+  store.on([event, another], (state, payload) => state)
+  expect(typecheck).toMatchInlineSnapshot(`
+"
+--typescript--
+No overload matches this call.
+  Overload 1 of 2, '(triggers: Unit<string>[], handler: (state: number, payload: string) => number | void): Store<number>', gave the following error.
+    Type 'Event<number>' is not assignable to type 'Unit<string>'.
+  Overload 2 of 2, '(trigger: Unit<unknown>, handler: (state: number, payload: unknown) => number | void): Store<number>', gave the following error.
+    Argument of type '(Store<string> | Event<number>)[]' is not assignable to parameter of type 'Unit<unknown>'.
+      Type '(Store<string> | Event<number>)[]' is missing the following properties from type 'Unit<unknown>': kind, __
+Parameter 'state' implicitly has an 'any' type.
+Parameter 'payload' implicitly has an 'any' type.
+
+--flow--
+Cannot call 'store.on' with array literal bound to 'triggers'
+  store.on([event, another], (state, payload) => state)
+           ^^^^^^^^^^^^^^^^
+  string [1] is incompatible with number [2] in type argument 'T' [3] of array element
+      const another = createStore('')
+                              [1] ^^
+      const event = createEvent<number>()
+                            [2] ^^^^^^
+      export interface Unit<T> extends CovariantUnit<T>, ContravariantUnit<T> {
+                        [3] ^
+"
+`)
+})
+
 test('#off', () => {
   const event = createEvent()
   const store = createStore(0)


### PR DESCRIPTION
```js
import {createEvent, createStore} from 'effector'

const store = createStore(0)
const changedA = createEvent()
const changedB = createEvent()

store.on([changedA, changedB], (state, params) => state + params)

store.watch(value => {
  console.log('updated', value)
})

changedA(2)
// => updated 2

changedB(2)
// => updated 4

store.off(changedB)
```