### PR TITLE
Fine-grained effector-vue watch binding

### DIFF
--- a/packages/effector-vue/index.d.ts
+++ b/packages/effector-vue/index.d.ts
@@ -4,7 +4,7 @@ import {
   ThisTypedComponentOptionsWithRecordProps,
 } from 'vue/types/options'
 import {ExtendedVue} from 'vue/types/vue'
-import {Store} from 'effector'
+import {Store, Unit} from 'effector'
 
 type Inference<EffectorState> = EffectorState extends Store<infer State>
   ? State
@@ -94,7 +94,7 @@ declare function createComponent<
 ): ExtendedVue<V, Data, Methods, Computed, PropNames>
 
 declare function createComponent<
-  S extends {[field: string]: Store<any>},
+  S extends {[field: string]: Store<any> | Unit<any>},
   V extends Vue,
   Data,
   Methods,

--- a/packages/effector-vue/index.d.ts
+++ b/packages/effector-vue/index.d.ts
@@ -4,7 +4,7 @@ import {
   ThisTypedComponentOptionsWithRecordProps,
 } from 'vue/types/options'
 import {ExtendedVue} from 'vue/types/vue'
-import {Store, Unit} from 'effector'
+import {Store, Event} from 'effector'
 
 type Inference<EffectorState> = EffectorState extends Store<infer State>
   ? State
@@ -94,7 +94,7 @@ declare function createComponent<
 ): ExtendedVue<V, Data, Methods, Computed, PropNames>
 
 declare function createComponent<
-  S extends {[field: string]: Store<any> | Unit<any>},
+  S extends {[field: string]: Store<any> | Event<any>},
   V extends Vue,
   Data,
   Methods,
@@ -111,7 +111,7 @@ declare function createComponent<
   store?: S,
 ): ExtendedVue<Inference<S> & V, Data, Methods, Computed, Props>
 declare function createComponent<
-  S extends {[field: string]: Store<any>},
+  S extends {[field: string]: Store<any> | Event<any>},
   V extends Vue,
   Data,
   Methods,

--- a/src/vue/__tests__/index.test.ts
+++ b/src/vue/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import {shallowMount, createLocalVue} from '@vue/test-utils'
-import {createStore} from 'effector'
+import {createStore, createEvent} from 'effector'
 import Vue from 'vue'
 import {VueEffector, createComponent} from 'effector-vue'
 
@@ -67,6 +67,23 @@ test('vue $watch', async() => {
 
   expect(wrapper.vm.counter).toBe(1)
   expect(mockCallback.mock.calls.length).toBe(1)
+})
+
+test('test SID if pass event to effector object', async() => {
+  const evt = createEvent()
+
+  const component = createComponent({
+    template: '<div>{{ evt }}</div>',
+  }, {evt})
+
+  const wrapper = shallowMount(component, {
+    localVue
+  })
+
+  evt()
+  // @ts-ignore
+  console.log(wrapper.vm.evt)
+  expect(wrapper.vm.evt).not.toBeNull()
 })
 
 test('vue component watch option', async() => {

--- a/src/vue/__tests__/index.test.ts
+++ b/src/vue/__tests__/index.test.ts
@@ -71,9 +71,16 @@ test('vue $watch', async() => {
 
 test('test SID if pass event to effector object', async() => {
   const evt = createEvent()
+  const mockCallback = jest.fn()
+
 
   const component = createComponent({
     template: '<div>{{ evt }}</div>',
+    watch: {
+      evt() {
+        mockCallback()
+      }
+    }
   }, {evt})
 
   const wrapper = shallowMount(component, {
@@ -82,8 +89,8 @@ test('test SID if pass event to effector object', async() => {
 
   evt()
   // @ts-ignore
-  console.log(wrapper.vm.evt)
-  expect(wrapper.vm.evt).not.toBeNull()
+  await wrapper.vm.$nextTick()
+  expect(mockCallback.mock.calls.length).toBe(1)
 })
 
 test('vue component watch option', async() => {


### PR DESCRIPTION
Access to pass an event to `effector` object. This event will return timestamp when called this event.

Motivation:

Handle when called this event and prevent this call on `watch` (vue API)

For example: 
I want to send data and then close popup on the view layer.

```
const send = createEffect({...});

export default {
  effector: {
    completed: send.done
  },
  watch: {
    completed() { this.closePopup() }
  }
}
```