### PR TITLE
console.log in REPL does not render Error objects in a right way

### DIFF
--- a/website/editor/src/features/logs/lib/console/react-inspector/fork/object-inspector/ObjectPreview.tsx
+++ b/website/editor/src/features/logs/lib/console/react-inspector/fork/object-inspector/ObjectPreview.tsx
@@ -35,6 +35,15 @@ const ObjectPreview = ({data, maxProperties}) => {
     return <ObjectValue object={object} />
   }
 
+  // Cannot check using instanceof Error
+  if (
+    typeof object === 'object' &&
+    typeof object.stack === 'string' &&
+    typeof object.message === 'string'
+  ) {
+    return <span style={styles.preview}>{`${object.stack}`}</span>
+  }
+
   if (Array.isArray(object)) {
     return (
       <span style={styles.preview}>


### PR DESCRIPTION
**Current behavior**: `Error` objects are rendered in REPL as empty `{}` object.
**Reproduction**: https://share.effector.dev/T0okfYak