### PR TITLE
small accessability fix for the website

### DIFF
--- a/website/client/src/pages/index.js
+++ b/website/client/src/pages/index.js
@@ -79,7 +79,7 @@ function Feature({imageUrl, title, description}) {
     <div className={classnames('col col--4', styles.feature)}>
       {imgUrl && (
         <div className="text--center">
-          <img className={styles.featureImage} src={imgUrl} alt={title} />
+          <img className={styles.featureImage} src={imgUrl} alt="" />
         </div>
       )}
       <h3 className="text--center">{title}</h3>


### PR DESCRIPTION
Those images don't need to have an alt tag, because they are decorative images. And by the way, it's also wrong to set an alt with text which is already on the screen cuz screen reader users will hear this text twice and that makes no sense.