### PR TITLE
fix: broken relative path in docs

### DIFF
--- a/website/client/docusaurus.config.js
+++ b/website/client/docusaurus.config.js
@@ -123,7 +123,7 @@ module.exports = {
           // Equivalent to `enableUpdateTime`.
           showLastUpdateTime: true,
           editUrl:
-            'https://github.com/zerobias/effector/edit/master/',
+            'https://github.com/zerobias/effector/edit/master/fix/relative-bug/',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
I wanted to fix a bug in the documentation and pressed "edit this page" and I was thrown somewhere wrong.\
After a little research, I realized that the bug was that docusaurus did not take into account the case, that the documentation could be higher than the file system level. The library connects[ `path` and `editUrl` ](https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-utils/src/index.ts#L350-L357) into one to get the final url (I don't know why). 
This causes the final url to lose 2 folders in the path and break the destination link.
This cannot be fixed quickly, but I have noticed that browsers handle relative url in links correctly, and it occurred to me to add subdirs in editUrl to get the correct final link.

wrong: 
![image](https://user-images.githubusercontent.com/11390039/86522348-07335380-be65-11ea-9678-59ea0221beb3.png)

correct:
![image](https://user-images.githubusercontent.com/11390039/86522341-f5ea4700-be64-11ea-8784-8dd729b53aac.png)
