### PR TITLE
add support for attach without mapParams and source simultaneously

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -818,6 +818,11 @@ export function attach<
   effect: FX
   name?: string
 }): Effect<void, EffectResult<FX>, EffectError<FX>>
+export function attach<
+  FX extends Effect<any, any, any>,
+>(config: {
+  effect: FX
+}): Effect<EffectParams<FX>, EffectResult<FX>, EffectError<FX>>
 
 export function withRegion(unit: Unit<any> | Node, cb: () => void): void
 export function combine<T extends Store<any>>(

--- a/packages/effector/index.js.flow
+++ b/packages/effector/index.js.flow
@@ -517,6 +517,10 @@ declare export function attach<Params, FXParams, FXResult, FXError>(config: {|
   +mapParams: (params: Params) => FXParams,
 |}): Effect<Params, FXResult, FXError>
 
+declare export function attach<Params, FXParams, FXResult, FXError>(config: {|
+  +effect: Effect<FXParams, FXResult, FXError>,
+|}): Effect<Params, FXResult, FXError>
+
 declare export function withRegion(unit: Unit<any> | Node, cb: () => void): void
 
 declare export function combine<State: StoreObject>(

--- a/src/effector/__tests__/attach.test.ts
+++ b/src/effector/__tests__/attach.test.ts
@@ -240,14 +240,51 @@ it('pass source to inner effect if no mapParams provided', async () => {
   await expect(fx()).resolves.toBe('ok')
 })
 
-it('throw error if no source nor mapParams provided', async () => {
-  const fx = createEffect<string, void>()
-  expect(() => {
-    //@ts-ignore
-    attach({effect: fx})
-  }).toThrowErrorMatchingInlineSnapshot(
-    `"either \`mapParams\` or \`source\` should be defined"`,
-  )
+it('if no source nor mapParams provided just create new derived effect', async () => {
+  const fn = jest.fn()
+  const $counter = createStore(0)
+  const originalFx = createEffect((params: number) => params * 10)
+  // @ts-expect-error no types yet
+  const derivedFx = attach({effect: originalFx})
+
+  $counter.on(originalFx.doneData, (counter, value) => counter + value)
+  $counter.on(derivedFx.doneData, (counter, value) => counter - value)
+
+  derivedFx.watch(params => {
+    fn({effect: 'derivedFx', params})
+  })
+  derivedFx.doneData.watch(data => {
+    fn({effect: 'derivedFx.doneData', data})
+  })
+  originalFx.watch(params => {
+    fn({effect: 'originalFx', params})
+  })
+  originalFx.doneData.watch(data => {
+    fn({effect: 'originalFx.doneData', data})
+  })
+
+  await derivedFx(3)
+  expect($counter.getState()).toBe(0)
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "effect": "derivedFx",
+        "params": 3,
+      },
+      Object {
+        "effect": "originalFx",
+        "params": 3,
+      },
+      Object {
+        "data": 30,
+        "effect": "originalFx.doneData",
+      },
+      Object {
+        "data": 30,
+        "effect": "derivedFx.doneData",
+      },
+    ]
+  `)
 })
 
 it('handle fatal errors in mapParams', async () => {

--- a/src/effector/__tests__/attach.test.ts
+++ b/src/effector/__tests__/attach.test.ts
@@ -244,7 +244,6 @@ it('if no source nor mapParams provided just create new derived effect', async (
   const fn = jest.fn()
   const $counter = createStore(0)
   const originalFx = createEffect((params: number) => params * 10)
-  // @ts-expect-error no types yet
   const derivedFx = attach({effect: originalFx})
 
   $counter.on(originalFx.doneData, (counter, value) => counter + value)

--- a/src/effector/attach.ts
+++ b/src/effector/attach.ts
@@ -17,9 +17,10 @@ export function attach(config: any) {
     config = userConfig
   })
   let {source, effect, mapParams} = config
-  if (!source && !mapParams)
-    throwError('either `mapParams` or `source` should be defined')
-  if (!mapParams) mapParams = (_: any, source: any) => source
+  if (!mapParams)
+    mapParams = source
+      ? (_: any, source: any) => source
+      : (params: any) => params
   const attached = createEffect(config, injected)
   const {runner} = getGraph(attached).scope
 

--- a/src/types/__tests__/effector/attach.test.js
+++ b/src/types/__tests__/effector/attach.test.js
@@ -87,3 +87,17 @@ test('mapParams without arguments (should pass)', () => {
     "
   `)
 })
+
+test('without source and mapParams', () => {
+  const effect: Effect<number, string, boolean> = createEffect()
+  const fx: Effect<number, string, boolean> = attach({effect})
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    --typescript--
+    no errors
+
+    --flow--
+    no errors
+    "
+  `)
+})

--- a/src/types/__tests__/effector/sample/targetForwarding.test.js
+++ b/src/types/__tests__/effector/sample/targetForwarding.test.js
@@ -114,14 +114,14 @@ it('should fail when a target receives a more loose value type from a mapping fn
         Type 'Store<null>' is not assignable to type 'Combinable'.
           Type 'Store<null>' is not assignable to type '{ [key: string]: Store<any>; }'.
             Index signature is missing in type 'Store<null>'.
-              Type '() => { a: string; }' is not assignable to type '(source: any[] | GetCombinedValue<{ [key: string]: Store<any>; }> | [any], clock: void) => { a: string; b: string; }'.
+              Type '() => { a: string; }' is not assignable to type '(source: any[] | [any] | GetCombinedValue<{ [key: string]: Store<any>; }>, clock: void) => { a: string; b: string; }'.
                 Property 'b' is missing in type '{ a: string; }' but required in type '{ a: string; b: string; }'.
     No overload matches this call.
       The last overload gave the following error.
         Type 'Store<null>' is not assignable to type 'Combinable'.
           Type 'Store<null>' is not assignable to type '{ [key: string]: Store<any>; }'.
             Index signature is missing in type 'Store<null>'.
-              Type '() => { a: string; }' is not assignable to type '(source: any[] | GetCombinedValue<{ [key: string]: Store<any>; }> | [any], clock: void) => { a: string; b: string; }'.
+              Type '() => { a: string; }' is not assignable to type '(source: any[] | [any] | GetCombinedValue<{ [key: string]: Store<any>; }>, clock: void) => { a: string; b: string; }'.
                 Property 'b' is missing in type '{ a: string; }' but required in type '{ a: string; b: string; }'.
 
     --flow--
@@ -176,13 +176,13 @@ describe('edge case for {} type', () => {
         The last overload gave the following error.
           Type 'Store<null>' is not assignable to type 'Combinable'.
             Type 'Store<null>' is not assignable to type '{ [key: string]: Store<any>; }'.
-              Type '() => {}' is not assignable to type '(source: any[] | GetCombinedValue<{ [key: string]: Store<any>; }> | [any], clock: void) => { a: string; b: string; }'.
+              Type '() => {}' is not assignable to type '(source: any[] | [any] | GetCombinedValue<{ [key: string]: Store<any>; }>, clock: void) => { a: string; b: string; }'.
                 Type '{}' is missing the following properties from type '{ a: string; b: string; }': a, b
       No overload matches this call.
         The last overload gave the following error.
           Type 'Store<null>' is not assignable to type 'Combinable'.
             Type 'Store<null>' is not assignable to type '{ [key: string]: Store<any>; }'.
-              Type '() => {}' is not assignable to type '(source: any[] | GetCombinedValue<{ [key: string]: Store<any>; }> | [any], clock: void) => { a: string; b: string; }'.
+              Type '() => {}' is not assignable to type '(source: any[] | [any] | GetCombinedValue<{ [key: string]: Store<any>; }>, clock: void) => { a: string; b: string; }'.
                 Type '{}' is missing the following properties from type '{ a: string; b: string; }': a, b
 
       --flow--


### PR DESCRIPTION
```ts
const originalFx = createEffect(() => {
  // your logic
})

const derivedFx = attach({ effect: originalFx })
```

inspired by: https://github.com/effector/patronum/issues/79