### PR TITLE
[TS] Void function interop

### DIFF
--- a/packages/effector/index.d.ts
+++ b/packages/effector/index.d.ts
@@ -83,6 +83,7 @@ export type CompositeName = {
 
 export interface Event<Payload> extends Unit<Payload> {
   (payload: Payload): Payload
+  (this: Payload extends void ? void : `Error: Expected 1 argument, but got 0`): void
   watch(watcher: (payload: Payload) => any): Subscription
   map<T>(fn: (payload: Payload) => T): Event<T>
   filter<T extends Payload>(config: {

--- a/src/types/__tests__/effector/effect.test.js
+++ b/src/types/__tests__/effector/effect.test.js
@@ -355,9 +355,6 @@ describe('#filterMap', () => {
       "
       --typescript--
       Type 'Event<number>' is not assignable to type 'Event<number | void>'.
-        Types of parameters 'payload' and 'payload' are incompatible.
-          Type 'number | void' is not assignable to type 'number'.
-            Type 'void' is not assignable to type 'number'.
 
       --flow--
       no errors

--- a/src/types/__tests__/effector/event.test.js
+++ b/src/types/__tests__/effector/event.test.js
@@ -148,3 +148,77 @@ describe('#filterMap', () => {
     `)
   })
 })
+test('void function interop (should pass)', () => {
+  /*::
+  type unknown = any;
+  type never = any;
+  */
+  const voidFn: () => void = createEvent<void>()
+  const voidFn1: () => void = createEvent</*:: typeof */ undefined>()
+  const voidFn2: () => void = createEvent<any>()
+  const voidFn3: () => void = createEvent<never>()
+  const voidFn4: () => void = createEvent<unknown>()
+  const event = createEvent()
+  event()
+  const event1 = createEvent</*:: typeof */ undefined>()
+  event1()
+  const event2 = createEvent<any>()
+  event2()
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    --typescript--
+    no errors
+
+    --flow--
+    no errors
+    "
+  `)
+})
+test('call event without params', () => {
+  const event = createEvent<number>()
+  event()
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    --typescript--
+    The 'this' context of type 'void' is not assignable to method's 'this' of type '\\"Error: Expected 1 argument, but got 0\\"'.
+
+    --flow--
+    Cannot call 'event'
+      event()
+      ^^^^^
+      function [1] requires another argument. [incompatible-call]
+          (payload: Payload): Payload;
+      [1] ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    "
+  `)
+})
+test('call event without params (unknown)', () => {
+  /*:: type unknown = any; */
+  // Expects 1 unknown argument
+  const event = createEvent<unknown>()
+  event()
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    --typescript--
+    The 'this' context of type 'void' is not assignable to method's 'this' of type '\\"Error: Expected 1 argument, but got 0\\"'.
+
+    --flow--
+    no errors
+    "
+  `)
+})
+test('call event without params (never)', () => {
+  /*:: type never = any; */
+  // Should never be called
+  const event = createEvent<never>()
+  event()
+  expect(typecheck).toMatchInlineSnapshot(`
+    "
+    --typescript--
+    The 'this' context of type 'void' is not assignable to method's 'this' of type 'never'.
+
+    --flow--
+    no errors
+    "
+  `)
+})


### PR DESCRIPTION
Use case:
```ts
  type voidFn = () => void
  const fn = (callback: voidFn) => {
    if(callback) callback()
  }
  const voidEvent: Event<void> = createEvent();
  fn(voidEvent); // TS2345: Argument of type 'Event ' is not assignable to parameter of type 'voidFn'.
```

This PR adds void function interop:

```ts
  const voidFn: () => void = createEvent<void>()
  const voidFn1: () => void = createEvent<undefined>()
  const voidFn2: () => void = createEvent<any>()

  const event1 = createEvent<undefined>()
  event1()
  const event2 = createEvent<any>()
  event2()
```

The only weak spot is the text of the message:

```ts
  const event1 = createEvent<number>()
  event1() /* Error
    The 'this' context of type 'void' is not assignable to method's 'this' of type '"Error:
	Expected 1 argument, but got 0"'.
  */
```

All tests pass!