### PR TITLE
Fix broken doc links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For additional information, guides and api reference visit [our documentation si
 
 ## Packages
 
-- [effector](c)
+- [effector](https://effector.dev/en/api/effector/)
 - [effector-react](https://effector.dev/en/api/effector-react/)
 - [effector-vue](https://effector.dev/en/api/effector-vue/)
 


### PR DESCRIPTION
Tried to follow links in README.md and failed. This PR fixes broken links from `https://effector.dev/docs/**` to `https://effector.dev/en/**/`

### Conventions
- [x] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates
