### PR TITLE
fix logo href in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://effector.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/effector/effector/master/website/client/static/img/comet.svg" alt="Effector Comet Logo" />
+    <img width="150" src="https://raw.githubusercontent.com/effector/effector/master/documentation/public/favicon.svg" alt="Effector Comet Logo" />
   </a>
 </p>
 <br />


### PR DESCRIPTION
The effector logo was pointing to a no longer existing image. 
I changed it to point to the [documentation/public/favicon.svg](https://github.com/effector/effector/blob/d6c0839ebcd925db1ec9e2b5f3828134d79af5a9/documentation/public/favicon.svg)

### Conventions
- [x] Please check your messages [against the guidelines](https://cbea.ms/git-commit/) if not, perform [interactive rebase](https://thoughtbot.com/blog/git-interactive-rebase-squash-amend-rewriting-history)
- [ ] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates (trivial change, no issue have been opened)
