### PR TITLE
fix(sample): respect batch option for shape source

### DIFF
--- a/src/effector/__tests__/sample/sample.test.ts
+++ b/src/effector/__tests__/sample/sample.test.ts
@@ -854,3 +854,41 @@ describe('greedy deprecation', () => {
     )
   })
 })
+
+test('source shape respects batch option', () => {
+  const appStarted = createEvent()
+  const $list = createStore<string[]>([])
+
+  const initOne = createEvent()
+  const initTwo = createEvent()
+  const firstName = createEvent<string>()
+  const secondName = createEvent<string>()
+
+  sample({
+    clock: initOne,
+    fn: () => 'hello',
+    target: firstName,
+  })
+  sample({
+    clock: initTwo,
+    fn: () => 'dudes',
+    target: secondName,
+  })
+
+  sample({
+    clock: appStarted,
+    target: [initOne, initTwo],
+  })
+
+  sample({
+    clock: [firstName, secondName],
+    source: {list: $list},
+    fn: ({list}, name) => [...list, name],
+    target: $list,
+    batch: false,
+  })
+
+  appStarted()
+
+  expect($list.getState()).toEqual(['hello', 'dudes'])
+})

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -99,6 +99,20 @@ export function combine(...args: any[]): Store<any> {
   )
 }
 
+export const combineSource = (shape: any, batch: boolean) => {
+  const errorTitle = generateErrorTitle('combine')
+  assert(isObject(shape), `${errorTitle}: shape should be an object`)
+  return storeCombination(
+    Array.isArray(shape),
+    true,
+    shape,
+    getUnitTrace(combine),
+    undefined,
+    undefined,
+    {batch},
+  )
+}
+
 const storeCombination = (
   isArray: boolean,
   needSpread: boolean,
@@ -106,9 +120,13 @@ const storeCombination = (
   unitTrace: string,
   config?: Config,
   fn?: (upd: any) => any,
-  extConfig?: false | {skipVoid?: boolean},
+  extConfig?: false | {skipVoid?: boolean; batch?: boolean},
 ) => {
   const errorTitle = generateErrorTitle('combine', config)
+  const {batch = true, ...storeConfig} = (extConfig || {}) as {
+    batch?: boolean
+    [key: string]: any
+  }
   const clone = isArray ? (list: any) => [...list] : (obj: any) => ({...obj})
   const defaultState: Record<string, any> = isArray ? [] : {}
 
@@ -121,7 +139,7 @@ const storeCombination = (
   const store = createStore(stateNew, {
     name: unitObjectName(obj),
     derived: true,
-    ...extConfig,
+    ...storeConfig,
     and: config,
   })
   setUnitTrace(store, unitTrace)
@@ -187,7 +205,7 @@ const storeCombination = (
      *
      *  basically, this makes `sample` and `combine` priorities equal
      */
-    read(rawShape, true, true),
+    read(rawShape, true, batch),
     fn && userFnCall(),
     softReader,
   ]
@@ -221,7 +239,7 @@ const storeCombination = (
     if (fn) {
       const computedValue = fn(stateNew)
 
-      if (isVoid(computedValue) && (!extConfig || !('skipVoid' in extConfig))) {
+      if (isVoid(computedValue) && !('skipVoid' in storeConfig)) {
         console.error(`${errorTitle}: ${requireExplicitSkipVoidMessage}`)
       }
 

--- a/src/effector/combine.ts
+++ b/src/effector/combine.ts
@@ -99,7 +99,7 @@ export function combine(...args: any[]): Store<any> {
   )
 }
 
-export const combineSource = (shape: any, batch: boolean) => {
+export const combineSource = (shape: unknown, batch: boolean) => {
   const errorTitle = generateErrorTitle('combine')
   assert(isObject(shape), `${errorTitle}: shape should be an object`)
   return storeCombination(
@@ -125,7 +125,7 @@ const storeCombination = (
   const errorTitle = generateErrorTitle('combine', config)
   const {batch = true, ...storeConfig} = (extConfig || {}) as {
     batch?: boolean
-    [key: string]: any
+    [key: string]: unknown
   }
   const clone = isArray ? (list: any) => [...list] : (obj: any) => ({...obj})
   const defaultState: Record<string, any> = isArray ? [] : {}

--- a/src/effector/sample.ts
+++ b/src/effector/sample.ts
@@ -1,6 +1,6 @@
 import type {Cmd, Node, StateRef} from './index.h'
 import type {CommonUnit, DataCarrier, Store} from './unit.h'
-import {combine} from './combine'
+import {combine, combineSource} from './combine'
 import {mov, userFnCall, read, calc} from './step'
 import {createStateRef, readRef} from './stateRef'
 import {callStackAReg} from './caller'
@@ -110,7 +110,7 @@ export const createSampling = (
   if (isVoid(source)) {
     sourceIsClock = true
   } else if (!is.unit(source)) {
-    source = combine(source)
+    source = batch ? combine(source) : combineSource(source, batch)
   }
   if (isVoid(clock)) {
     /** still undefined! */


### PR DESCRIPTION
### Conventions
- [x] Please check your messages [against the guidelines](https://cbea.ms/git-commit/)
- [x] [Link an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) your pull request closes or relates

Closes #1211
Supersedes #1321

## Problem
`sample` has two source paths:
- `source: $store`
- `source: { list: $store }` (shape, internally uses combine)

With `batch: false`, shape-source path could read stale value in the same tick because internal combine sampler-read was still batched.

## Solution
- In `sample`, for shape-source:
  - keep `combine(source)` for `batch: true`
  - use `combineSource(shape, batch)` for `batch: false`
- In `combine`, pass `batch` to internal sampler read: `read(rawShape, true, batch)`.
- Follow-up types cleanup in second commit: replaced newly added `any` with `unknown` in this path.

## Result
No stale reads for shape-source with `batch: false`.

## Regression test
Added test for reported scenario:
- source shape + `batch: false`
- sequential same-tick updates
- expected state: `['hello', 'dudes']`

## Local checks
- `yarn test`
- `yarn build`
