### PR TITLE
Add BrowserStack performance budget checks

### DIFF
--- a/src/compat/README.md
+++ b/src/compat/README.md
@@ -16,3 +16,8 @@ These tests expects `.env` file with variables `BROWSERSTACK_USERNAME` and `BROW
 BROWSERSTACK_USERNAME=username
 BROWSERSTACK_ACCESS_KEY=key
 ```
+
+The BrowserStack suite also runs a small performance budget check on the same
+device matrix. It measures common graph update and graph creation paths and
+fails only when a device is far outside the expected budget, so compatibility
+and performance regressions are caught together.

--- a/src/compat/perf.test.ts
+++ b/src/compat/perf.test.ts
@@ -1,0 +1,102 @@
+import {combine, createEvent, createStore, sample} from 'effector'
+
+declare const initBrowser: () => Promise<void>
+declare const browser: any
+declare const execFunc: <T>(cb: () => Promise<T> | T) => Promise<T>
+
+type PerfResult = {
+  name: string
+  totalMs: number
+  iterations: number
+  msPerIteration: number
+  budgetMsPerIteration: number
+}
+
+beforeEach(async () => {
+  await initBrowser()
+}, 10e3)
+
+test('performance budget on real devices', async () => {
+  const results = await execFunc(async () => {
+    function now() {
+      if (typeof performance !== 'undefined' && performance.now) {
+        return performance.now()
+      }
+      return Date.now()
+    }
+
+    function round(value: number) {
+      return Math.round(value * 1000) / 1000
+    }
+
+    function runBenchmark(
+      name: string,
+      iterations: number,
+      budgetMsPerIteration: number,
+      fn: (index: number) => void,
+    ) {
+      for (let index = 0; index < 20; index += 1) {
+        fn(index)
+      }
+
+      const startedAt = now()
+      for (let index = 0; index < iterations; index += 1) {
+        fn(index)
+      }
+      const totalMs = now() - startedAt
+
+      return {
+        name,
+        totalMs: round(totalMs),
+        iterations,
+        msPerIteration: round(totalMs / iterations),
+        budgetMsPerIteration,
+      }
+    }
+
+    const update = createEvent<number>()
+    const $source = createStore(0).on(update, (_, value) => value)
+    const $mapped = $source.map(value => value + 1)
+    const $combined = combine({source: $source, mapped: $mapped})
+    const sampled = sample({source: $combined, clock: update})
+
+    let observed = 0
+    $combined.watch(value => {
+      observed += value.mapped
+    })
+    sampled.watch(value => {
+      observed += value.source
+    })
+
+    const updateResult = runBenchmark(
+      'event-to-store graph update',
+      1000,
+      10,
+      index => {
+        update(index)
+      },
+    )
+
+    const graphResult = runBenchmark('store graph creation', 25, 80, index => {
+      const source = createStore(index)
+      const next = source.map(value => value + 1)
+      const combined = combine([source, next], list => list[0] + list[1])
+      combined.watch(() => {})
+    })
+
+    return {observed, results: [updateResult, graphResult]}
+  })
+
+  expect(results.observed).toBeGreaterThan(0)
+  for (const result of results.results) {
+    expect(result.totalMs).toBeGreaterThanOrEqual(0)
+    expect(result.msPerIteration).toBeLessThanOrEqual(
+      result.budgetMsPerIteration,
+    )
+  }
+
+  console.log(
+    `[${browser.capabilities.browserName || browser.capabilities.deviceName}]`,
+    results.results,
+  )
+})


### PR DESCRIPTION
This adds a small performance budget test to the existing BrowserStack compatibility suite. It runs on the same device/browser matrix as `yarn browserstack` and covers two common paths: event-to-store graph updates and store graph creation.

The budgets are intentionally broad, so the test should only fail on clear regressions or device/runtime problems rather than normal variance between BrowserStack sessions. I also updated the compat README to mention that the BrowserStack suite now includes the performance check.

Checked:
- `yarn install --frozen-lockfile`
- `./node_modules/.bin/prettier --check src/compat/perf.test.ts src/compat/README.md`
- `./node_modules/.bin/eslint src/compat/perf.test.ts`
- targeted TypeScript check for `src/compat/perf.test.ts`
- Babel transform for `src/compat/perf.test.ts`
- `NO_TYPE_TESTS=true npx jest --config=jest.config.js --selectProjects effector --runTestsByPath src/effector/__tests__/perf.test.ts --runInBand`
- `yarn build`

I could not run `yarn browserstack` because it requires `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY`.

Closes #161


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#161: Perf tests on real devices](https://oss.issuehunt.io/repos/123197392/issues/161)
---
</details>
<!-- /Issuehunt content-->