### PR TITLE
fix(docs): improve iOS touch scrolling in docs navigation

### DIFF
--- a/documentation/src/components/LeftSidebar/LeftSidebar.astro
+++ b/documentation/src/components/LeftSidebar/LeftSidebar.astro
@@ -383,6 +383,7 @@ const languageLinks = createChangeLangLinks({ slug });
     overflow-y: auto;
     overflow-x: visible;
     overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
     scrollbar-gutter: stable;
     padding-bottom: var(--space-4);
   }

--- a/documentation/src/components/MobileNavigation.astro
+++ b/documentation/src/components/MobileNavigation.astro
@@ -61,6 +61,7 @@ const activeNavigation = markActiveNavigation(`/${slug.replace(/\/$/, "")}`, MOB
     will-change: transform, opacity;
     contain: layout style;
     backface-visibility: hidden;
+    -webkit-overflow-scrolling: touch;
     background-color: var(--theme-bg-mobile-menu);
   }
 
@@ -69,6 +70,7 @@ const activeNavigation = markActiveNavigation(`/${slug.replace(/\/$/, "")}`, MOB
     font-family: "Lexend Deca", sans-serif;
 
     overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
     padding-left: max(env(safe-area-inset-left), 1rem);
     padding-right: max(env(safe-area-inset-right), 1rem);
   }

--- a/documentation/src/components/RightSidebar/RightSidebar.astro
+++ b/documentation/src/components/RightSidebar/RightSidebar.astro
@@ -30,6 +30,7 @@ const { headings, documentId, lang } = Astro.props;
     padding-left: 0;
     height: 100%;
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
     color: var(--doc-fg-secondary);
   }
 </style>

--- a/documentation/src/components/RightSidebar/TableOfContents.module.css
+++ b/documentation/src/components/RightSidebar/TableOfContents.module.css
@@ -156,6 +156,7 @@
   max-height: 60vh;
   overflow-y: auto;
   overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   background-color: color-mix(in srgb, var(--theme-bg-sidebar-tabs-bg) 85%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);


### PR DESCRIPTION
## Summary
- enable iOS momentum scrolling in docs sidebars and mobile navigation by adding `-webkit-overflow-scrolling: touch`
- apply the fix to the main scroll containers users interact with on iOS Safari

## Files changed
- `documentation/src/components/LeftSidebar/LeftSidebar.astro`
- `documentation/src/components/MobileNavigation.astro`
- `documentation/src/components/RightSidebar/RightSidebar.astro`
- `documentation/src/components/RightSidebar/TableOfContents.module.css`

## Why
Issue #142 reports bad scrolling behavior on iOS mobile. This update improves scroll inertia and touch scrolling UX in the docs UI.

## Validation
- docs/frontend CSS change only
- verified changes are scoped to scrollable containers


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#142: Better Try Effector experience on mobile devices](https://oss.issuehunt.io/repos/123197392/issues/142)
---
</details>
<!-- /Issuehunt content-->