### PR TITLE
test(compat): add BrowserStack performance budgets

### DIFF
--- a/src/compat/perf.test.ts
+++ b/src/compat/perf.test.ts
@@ -1,0 +1,127 @@
+declare const initBrowser: () => Promise<void>
+declare const execFunc: <T>(cb: () => Promise<T> | T) => Promise<T>
+declare const effector: any
+
+type PerfMeasure = {
+  name: string
+  duration: number
+  iterations: number
+  msPerIteration: number
+}
+
+const eventPropagationBudget = 2
+const derivedGraphBudget = 10
+
+beforeEach(async () => {
+  await initBrowser()
+}, 10e3)
+
+test('event propagation stays within performance budget', async () => {
+  const result = await execFunc<PerfMeasure>(() => {
+    const {createEvent, createStore} = effector
+    const now = () =>
+      typeof performance !== 'undefined' && performance.now
+        ? performance.now()
+        : Date.now()
+    const increment = createEvent()
+    const $count = createStore(0).on(increment, value => value + 1)
+    const warmTimes = 100
+    const iterations = 2000
+    let updates = 0
+
+    $count.watch(() => {
+      updates += 1
+    })
+
+    for (let index = 0; index < warmTimes; index += 1) {
+      increment()
+    }
+
+    updates = 0
+    const start = now()
+
+    for (let index = 0; index < iterations; index += 1) {
+      increment()
+    }
+
+    const duration = now() - start
+
+    if ($count.getState() !== warmTimes + iterations) {
+      throw Error('unexpected store state after performance test')
+    }
+    if (updates !== iterations) {
+      throw Error('unexpected update count after performance test')
+    }
+
+    return {
+      name: 'event propagation',
+      duration,
+      iterations,
+      msPerIteration: duration / iterations,
+    }
+  })
+
+  expect(result.msPerIteration).toBeLessThanOrEqual(eventPropagationBudget)
+})
+
+test('derived graph updates stay within performance budget', async () => {
+  const result = await execFunc<PerfMeasure>(() => {
+    const {combine, createEvent, createStore} = effector
+    const now = () =>
+      typeof performance !== 'undefined' && performance.now
+        ? performance.now()
+        : Date.now()
+    const tick = createEvent()
+    const $source = createStore(0).on(tick, value => value + 1)
+    const stores = [$source]
+    const warmTimes = 20
+    const iterations = 400
+    let updates = 0
+
+    for (let index = 0; index < 64; index += 1) {
+      const previous = stores[stores.length - 1]
+      stores.push(previous.map(value => value + index))
+    }
+
+    const $sum = combine(stores, values => {
+      let total = 0
+      for (let index = 0; index < values.length; index += 1) {
+        total += values[index]
+      }
+      return total
+    })
+
+    $sum.watch(() => {
+      updates += 1
+    })
+
+    for (let index = 0; index < warmTimes; index += 1) {
+      tick()
+    }
+
+    updates = 0
+    const start = now()
+
+    for (let index = 0; index < iterations; index += 1) {
+      tick()
+    }
+
+    const duration = now() - start
+
+    if ($source.getState() !== warmTimes + iterations) {
+      throw Error('unexpected source state after performance test')
+    }
+    if (updates !== iterations) {
+      throw Error('unexpected derived update count after performance test')
+    }
+
+    return {
+      name: 'derived graph updates',
+      duration,
+      iterations,
+      msPerIteration: duration / iterations,
+    }
+  })
+
+  expect(result.msPerIteration).toBeLessThanOrEqual(derivedGraphBudget)
+})


### PR DESCRIPTION
## Summary

Adds BrowserStack compatibility performance checks so the existing real-device/browser matrix can catch large runtime regressions.

## Changes

- Added `src/compat/perf.test.ts` with two budgeted workloads:
  - event/store propagation throughput
  - derived graph recomputation throughput
- Reuses the existing BrowserStack runner globals and browser `performance.now()` with a `Date.now()` fallback.

## Tests

- ./.codex-bounty/run_allowed_tests.sh
- Docker inner commands:
  - corepack enable && yarn test
  - corepack enable && yarn run build
- Result: passed

## Risk

Low. The change is limited to BrowserStack compatibility tests and does not alter runtime library code, package metadata, CI, credentials, or dependencies.

## AI-assisted disclosure

This contribution was prepared with AI assistance.

## Related issue

Closes effector/effector#161

This is an AI-assisted contribution. I used Codex to help prepare the patch and verified the changes described above.

---

## Hunter Gate

- Related issue: Refs https://github.com/effector/effector/issues/161
- Issue key: effector/effector#161
- AI-assisted contribution disclosure: This is an AI-assisted contribution. I used Codex to help prepare the patch and verified the changes described above.
- Tests run by hunter.py:
- ./.codex-bounty/run_allowed_tests.sh
- Docker inner commands:
  - corepack enable && yarn test
  - corepack enable && yarn run build
- Result: passed
- Tests passed: True
- Changed files: src/compat/perf.test.ts
- Risk reported by Codex: low
- Risk gate: forbidden path and forbidden keyword checks passed before PR creation.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#161: Perf tests on real devices](https://oss.issuehunt.io/repos/123197392/issues/161)
---
</details>
<!-- /Issuehunt content-->