### PR TITLE
Expose graph links through inspectGraph

### DIFF
--- a/documentation/src/content/docs/en/api/effector/inspect.mdx
+++ b/documentation/src/content/docs/en/api/effector/inspect.mdx
@@ -161,6 +161,55 @@ const $count = createStore(0);
 // logs "store $count" to console
 ```
 
+## Graph relationships (#inspect-graph-relationships)
+
+`inspectGraph` can also report node relationships for developer tools that need to build a graph of units and intermediate nodes. Pass `includeLinks: true` to receive `graph` metadata on unit declarations and additional `link` declarations for internal relationship nodes.
+
+The `graph` field contains node IDs only:
+
+- `owners`: nodes that own the current node in the ownership graph
+- `links`: nodes owned by the current node
+- `next`: nodes triggered after the current node in the computation graph
+
+### Example (#inspect-graph-relationships-example)
+
+```ts
+import { createEvent, createStore, sample } from "effector";
+import { inspectGraph, type Declaration } from "effector/inspect";
+
+const nodes = new Map<string, { id: string; label: string; kind?: string }>();
+const edges: Array<{ source: string; target: string; kind?: string }> = [];
+
+inspectGraph({
+  includeLinks: true,
+  fn: (d: Declaration) => {
+    if (d.type === "unit") {
+      nodes.set(d.id, { id: d.id, label: d.name ?? d.id, kind: d.kind });
+    }
+
+    if (d.type === "link") {
+      for (const owner of d.graph.owners) {
+        edges.push({ source: owner, target: d.id, kind: d.kind });
+      }
+
+      for (const target of d.graph.links) {
+        edges.push({ source: d.id, target, kind: d.kind });
+      }
+    }
+  },
+});
+
+const started = createEvent();
+const finished = createEvent();
+const $count = createStore(0);
+
+sample({
+  clock: started,
+  source: $count,
+  target: finished,
+});
+```
+
 ## `withRegion` (#inspect-graph-withRegion)
 
 Meta-data provided via region's root node is available on declaration.

--- a/documentation/src/content/docs/ru/api/effector/inspect.mdx
+++ b/documentation/src/content/docs/ru/api/effector/inspect.mdx
@@ -159,6 +159,55 @@ const $count = createStore(0);
 // выведет "store $count" в консоль
 ```
 
+## Связи графа (#inspect-graph-relationships)
+
+`inspectGraph` также может сообщать связи между узлами для девтулз, которым нужно построить граф юнитов и промежуточных узлов. Передайте `includeLinks: true`, чтобы получить метаданные `graph` у объявлений юнитов и дополнительные объявления `link` для внутренних узлов связей.
+
+Поле `graph` содержит только ID узлов:
+
+- `owners`: узлы, которые владеют текущим узлом в графе владения
+- `links`: узлы, которыми владеет текущий узел
+- `next`: узлы, которые запускаются после текущего узла в графе вычислений
+
+### Пример (#inspect-graph-relationships-example)
+
+```ts
+import { createEvent, createStore, sample } from "effector";
+import { inspectGraph, type Declaration } from "effector/inspect";
+
+const nodes = new Map<string, { id: string; label: string; kind?: string }>();
+const edges: Array<{ source: string; target: string; kind?: string }> = [];
+
+inspectGraph({
+  includeLinks: true,
+  fn: (d: Declaration) => {
+    if (d.type === "unit") {
+      nodes.set(d.id, { id: d.id, label: d.name ?? d.id, kind: d.kind });
+    }
+
+    if (d.type === "link") {
+      for (const owner of d.graph.owners) {
+        edges.push({ source: owner, target: d.id, kind: d.kind });
+      }
+
+      for (const target of d.graph.links) {
+        edges.push({ source: d.id, target, kind: d.kind });
+      }
+    }
+  },
+});
+
+const started = createEvent();
+const finished = createEvent();
+const $count = createStore(0);
+
+sample({
+  clock: started,
+  source: $count,
+  target: finished,
+});
+```
+
 ## `withRegion` (#inspect-graph-withRegion)
 
 Метаданные, предоставленные через корневой узел региона, доступны при объявлении.

--- a/packages/effector/inspect.d.ts
+++ b/packages/effector/inspect.d.ts
@@ -44,6 +44,12 @@ type Region =
       }
     }
 
+type GraphLinks = {
+  owners: string[]
+  links: string[]
+  next: string[]
+}
+
 export type Declaration =
   | {
       type: 'unit'
@@ -58,8 +64,29 @@ export type Declaration =
       }
       meta: Record<string, unknown>
       region?: Show<Region>
+      graph?: GraphLinks
       // for derived units - stores or events
       derived?: boolean
+    }
+  | {
+      type: 'link'
+      id: string
+      kind?: string
+      name?: string
+      loc?: {
+        file: string
+        line: number
+        column: number
+      }
+      meta: Record<string, unknown>
+      region?: Show<Region>
+      graph: GraphLinks
+      // these fields are not provided to graph links
+      // however, to make it easier to work with it in Typescript
+      // and to avoid annoying `some prop does not exist` errors
+      derived?: undefined
+      sid?: undefined
+      method?: undefined
     }
   | {
       type: 'factory'
@@ -99,5 +126,6 @@ export type Declaration =
     }
 
 export function inspectGraph(config: {
+  includeLinks?: boolean
   fn: (declaration: Declaration) => void
 }): Subscription

--- a/src/effector/__tests__/inspect.test.ts
+++ b/src/effector/__tests__/inspect.test.ts
@@ -405,6 +405,95 @@ describe('inspectGraph API', () => {
 
     expect(argumentHistory(declMock)).toEqual(history)
   })
+  test('should not include graph metadata by default', () => {
+    const declarations: Declaration[] = []
+    const unsub = inspectGraph({
+      fn: d => declarations.push(d),
+    })
+
+    const start = createEvent()
+    const target = createEvent()
+    const $source = createStore(0)
+
+    sample({
+      clock: start,
+      source: $source,
+      target,
+    })
+
+    unsub()
+
+    expect(declarations.some(d => d.type === 'link')).toBe(false)
+    expect(
+      declarations.some(d => d.type === 'unit' && d.graph !== undefined),
+    ).toBe(false)
+  })
+  test('should include graph links for visualization when requested', () => {
+    const declarations: Declaration[] = []
+    const unsub = inspectGraph({
+      includeLinks: true,
+      fn: d => declarations.push(d),
+    })
+
+    const start = createEvent()
+    const target = createEvent()
+    const $source = createStore(0)
+    const $mapped = $source.map(value => value + 1)
+
+    sample({
+      clock: start,
+      source: $source,
+      target,
+    })
+
+    unsub()
+
+    const units = declarations.filter(
+      (d): d is Extract<Declaration, {type: 'unit'}> => d.type === 'unit',
+    )
+    const links = declarations.filter(
+      (d): d is Extract<Declaration, {type: 'link'}> => d.type === 'link',
+    )
+
+    const startDeclaration = units.find(
+      d => d.id === (start as any).graphite.id,
+    )!
+    const targetDeclaration = units.find(
+      d => d.id === (target as any).graphite.id,
+    )!
+    const sourceDeclaration = units.find(
+      d => d.id === ($source as any).graphite.id,
+    )!
+    const mappedDeclaration = units.find(
+      d => d.id === ($mapped as any).graphite.id,
+    )!
+
+    expect(units.every(d => d.graph)).toBe(true)
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.filter(d => d.kind === 'sample')).toHaveLength(1)
+    expect(links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'map',
+          graph: expect.objectContaining({
+            owners: expect.arrayContaining([sourceDeclaration.id]),
+            links: expect.arrayContaining([mappedDeclaration.id]),
+          }),
+        }),
+        expect.objectContaining({
+          kind: 'sample',
+          graph: expect.objectContaining({
+            owners: expect.arrayContaining([
+              startDeclaration.id,
+              targetDeclaration.id,
+              sourceDeclaration.id,
+            ]),
+            links: expect.arrayContaining([targetDeclaration.id]),
+          }),
+        }),
+      ]),
+    )
+  })
   describe('region support', () => {
     test('one-level withRegion', () => {
       function customOperator(config: Record<string, unknown>) {

--- a/src/effector/createNode.ts
+++ b/src/effector/createNode.ts
@@ -2,7 +2,7 @@ import type {Node, NodeUnit, Cmd} from './index.h'
 import {getGraph, getOwners, getLinks, getValue} from './getter'
 import {nextNodeID} from './id'
 import {CROSSLINK} from './tag'
-import {regionStack} from './region'
+import {regionStack, reportDeclaration} from './region'
 import {own} from './own'
 import {add, forEach} from './collection'
 
@@ -22,6 +22,7 @@ export function createNode({
   meta = {},
   family: familyRaw = {type: 'regular'},
   regional,
+  deferDeclaration,
 }: {
   node?: Array<Cmd | false | void | null>
   from?: NodeUnit | NodeUnit[]
@@ -38,6 +39,7 @@ export function createNode({
     owners?: NodeUnit | Array<NodeUnit | NodeUnit[]>
   }
   regional?: boolean
+  deferDeclaration?: boolean
 } = {}): Node {
   const sources = arrifyNodes(parent)
   const links = arrifyNodes(familyRaw.links)
@@ -62,6 +64,9 @@ export function createNode({
   forEach(sources, source => add(source.next, result))
   if (regional && regionStack) {
     own(getValue(regionStack), [result])
+  }
+  if (!deferDeclaration) {
+    reportDeclaration(result)
   }
   return result
 }

--- a/src/effector/forward.ts
+++ b/src/effector/forward.ts
@@ -12,6 +12,7 @@ export const createLinkNode = (
   node?: Array<Cmd | false | void | null>,
   op?: string,
   scopeFn?: Function,
+  deferDeclaration?: boolean,
 ) =>
   createNode({
     node,
@@ -21,6 +22,7 @@ export const createLinkNode = (
     meta: {op},
     family: {owners: [parent, child], links: child},
     regional: true,
+    deferDeclaration,
   })
 export const forward = (opts: {
   from: NodeUnit | NodeUnit[]

--- a/src/effector/inspect.ts
+++ b/src/effector/inspect.ts
@@ -28,6 +28,12 @@ type NodeCommonMeta = {
   derived?: boolean
 }
 
+type GraphLinks = {
+  owners: string[]
+  links: string[]
+  next: string[]
+}
+
 // Watch calculations
 type Message = {
   type: 'update' | 'error'
@@ -124,31 +130,43 @@ type UnitDeclaration = {
   type: 'unit'
   meta: Record<string, unknown>
   region?: Region
+  graph?: GraphLinks
 } & NodeCommonMeta
 
-type Declaration = UnitDeclaration | Region
+type LinkDeclaration = {
+  type: 'link'
+  id: string
+  name?: string
+  kind?: string
+  meta: Record<string, unknown>
+  loc?: Loc
+  region?: Region
+  graph: GraphLinks
+}
+
+type Declaration = UnitDeclaration | LinkDeclaration | Region
 
 const inspectGraphSubs = new Set<{
+  includeLinks?: boolean
   fn: (declaration: Declaration) => void
 }>()
 
 setGraphInspector((node: Node | 'region', regionStack: RegionStack) => {
-  let decl: Declaration | undefined
+  inspectGraphSubs.forEach(sub => {
+    const decls =
+      node === 'region'
+        ? [readRegionStack(regionStack)]
+        : readNodeDeclarations(node, regionStack, sub.includeLinks)
 
-  if (node === 'region') {
-    decl = readRegionStack(regionStack)
-  } else {
-    decl = readUnitDeclaration(node, regionStack)
-  }
-
-  if (decl) {
-    inspectGraphSubs.forEach(sub => {
-      sub.fn(decl!)
+    decls.forEach(decl => {
+      if (!decl) return
+      sub.fn(decl)
     })
-  }
+  })
 })
 
 export function inspectGraph(config: {
+  includeLinks?: boolean
   fn: (declaration: Declaration) => void
 }): Subscription {
   inspectGraphSubs.add(config)
@@ -205,13 +223,31 @@ function collectMessageTrace(stack: Stack) {
   return trace
 }
 
+function readNodeDeclarations(
+  node: Node,
+  regionStack: RegionStack,
+  includeLinks?: boolean,
+): Declaration[] {
+  if (node.meta.id || node.meta.rootStateRefId) {
+    return [readUnitDeclaration(node, regionStack, includeLinks)]
+  }
+
+  if (isUnitKind(node.meta.op)) return []
+
+  if (!includeLinks) return []
+
+  const linkDeclaration = readLinkDeclaration(node, regionStack)
+  return linkDeclaration ? [linkDeclaration] : []
+}
+
 function readUnitDeclaration(
   node: Node,
   regionStack: RegionStack,
+  includeLinks?: boolean,
 ): UnitDeclaration {
   const nodeMeta = readNodeMeta(node)
 
-  return {
+  const declaration: UnitDeclaration = {
     type: 'unit',
     region: readRegionStack(regionStack),
     meta: nodeMeta.meta,
@@ -221,6 +257,43 @@ function readUnitDeclaration(
     kind: nodeMeta.kind,
     loc: nodeMeta.loc,
     derived: nodeMeta.derived,
+  }
+
+  if (includeLinks) {
+    declaration.graph = readGraphLinks(node)
+  }
+
+  return declaration
+}
+
+function readLinkDeclaration(
+  node: Node,
+  regionStack: RegionStack,
+): LinkDeclaration | undefined {
+  const graph = readGraphLinks(node)
+  if (!graph.owners.length && !graph.links.length && !graph.next.length) return
+
+  return {
+    type: 'link',
+    id: node.id,
+    name: node.meta.name,
+    kind: node.meta.op,
+    meta: node.meta,
+    loc: getLoc(node.meta),
+    region: readRegionStack(regionStack),
+    graph,
+  }
+}
+
+function isUnitKind(kind: unknown) {
+  return kind === 'event' || kind === 'store' || kind === 'effect'
+}
+
+function readGraphLinks(node: Node): GraphLinks {
+  return {
+    owners: node.family.owners.map(({id}) => id),
+    links: node.family.links.map(({id}) => id),
+    next: node.next.map(({id}) => id),
   }
 }
 

--- a/src/effector/sample.ts
+++ b/src/effector/sample.ts
@@ -24,6 +24,7 @@ import {applyTemplate} from './template'
 import {own} from './own'
 import {createLinkNode} from './forward'
 import {generateErrorTitle} from './naming'
+import {reportDeclaration} from './region'
 
 const sampleConfigFields = ['source', 'clock', 'target']
 
@@ -233,12 +234,14 @@ export const createSampling = (
     ],
     method,
     fn,
+    true,
   )
   // @ts-expect-error
   own(source, [jointNode])
   own(jointNode, syncNodes)
   Object.assign(jointNode.meta, metadata, {joint: true, stateRef: clockState})
   setUnitTrace(jointNode, getUnitTrace(sample))
+  reportDeclaration(jointNode)
   return target
 }
 


### PR DESCRIPTION
## What changed

This adds an opt-in `includeLinks` mode to `inspectGraph()` so developer tools can collect enough graph metadata to build relationships between units and internal link nodes.

- keeps the default `inspectGraph({ fn })` declaration stream unchanged
- adds `graph` metadata to unit declarations only when `includeLinks: true` is used
- emits `link` declarations for internal relationship nodes with `owners`, `links`, and `next` node IDs
- reports sample link declarations after source ownership is attached so the emitted relation is complete
- documents the graph relationship mode in the English and Russian inspect docs

This is intended as a small core API step for visualization tooling related to #91. It does not try to replace the much larger devtools/UI work in #1320.

## Validation

- `npx yarn@1.22.22 test src/effector/__tests__/inspect.test.ts --runInBand`
- `npx yarn@1.22.22 test src/effector/__tests__/sample/sample.test.ts --runInBand`
- `git diff --check`

Relates to #91


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#91: Visualization for stores, events and relationships](https://oss.issuehunt.io/repos/123197392/issues/91)
---
</details>
<!-- /Issuehunt content-->