### PR TITLE
fix(babel-plugin): support Babel 8 factory template placeholders

### DIFF
--- a/src/babel/__tests__/factory-template.test.js
+++ b/src/babel/__tests__/factory-template.test.js
@@ -1,0 +1,69 @@
+import {transformSync} from '@babel/core'
+
+import babelPlugin from '../babel-plugin'
+import {formatCode} from './utils'
+
+/**
+ * Regression: Babel 8 requires @babel/template replacements to be
+ * identifiers or AST nodes. Passing JSON.stringify(...) for sid/name/method
+ * breaks factory wrapping under Babel 8.
+ */
+describe('factory template placeholders', () => {
+  const source = `
+    import {createQuery} from '@farfetched/core'
+    import {debounce} from 'patronum'
+
+    const q = createQuery({handler: async () => null})
+    debounce({source: q, timeout: 100})
+  `
+
+  it('wraps factories with stringLiteral sid/name/method (addLoc)', () => {
+    const {code} = transformSync(source, {
+      configFile: false,
+      babelrc: false,
+      filename: 'factory-template.test.js',
+      plugins: [
+        [
+          babelPlugin,
+          {
+            addLoc: true,
+            addNames: true,
+            factories: ['@farfetched/core', 'patronum'],
+          },
+        ],
+      ],
+    })
+
+    const formatted = formatCode(code)
+    expect(formatted).toContain("sid: '")
+    expect(formatted).toContain("name: 'q'")
+    expect(formatted).toContain("method: 'createQuery'")
+    expect(formatted).toContain("name: 'none'")
+    expect(formatted).toContain("method: 'debounce'")
+    expect(formatted).toMatch(/withFactory/)
+  })
+
+  it('wraps factories with stringLiteral sid only (no names/loc)', () => {
+    const {code} = transformSync(source, {
+      configFile: false,
+      babelrc: false,
+      filename: 'factory-template.test.js',
+      plugins: [
+        [
+          babelPlugin,
+          {
+            addLoc: false,
+            addNames: false,
+            factories: ['@farfetched/core', 'patronum'],
+          },
+        ],
+      ],
+    })
+
+    const formatted = formatCode(code)
+    expect(formatted).toContain("sid: '")
+    expect(formatted).not.toContain('name:')
+    expect(formatted).not.toContain('method:')
+    expect(formatted).toMatch(/withFactory/)
+  })
+})

--- a/src/babel/plugin/transform/factory.ts
+++ b/src/babel/plugin/transform/factory.ts
@@ -64,16 +64,17 @@ export function transformFactory(
     loc!.column,
     debugSids,
   )
+  // @babel/template string placeholders must be identifiers or AST nodes.
   const factoryConfig: Parameters<FactoryTemplate>[0] = {
-    SID: JSON.stringify(sid),
+    SID: t.stringLiteral(sid),
     FN: node,
     FACTORY: withFactoryImportName,
   }
   if (addLoc || addNames) {
-    factoryConfig.NAME = JSON.stringify(
+    factoryConfig.NAME = t.stringLiteral(
       !resultName || resultName === '' ? 'none' : resultName,
     )
-    factoryConfig.METHOD = JSON.stringify(importedName)
+    factoryConfig.METHOD = t.stringLiteral(importedName)
   }
   if (addLoc) {
     factoryConfig.LOC = makeTrace(

--- a/src/babel/plugin/types.ts
+++ b/src/babel/plugin/types.ts
@@ -5,6 +5,7 @@ import type {
   IfStatement,
   ImportDeclaration,
   ObjectExpression,
+  StringLiteral,
   TaggedTemplateExpression,
   Identifier,
 } from '@babel/types'
@@ -23,11 +24,11 @@ export type CreateHMRRegionTemplate = (params: {
 }) => VariableDeclaration
 
 export type FactoryTemplate = (params: {
-  SID: string
+  SID: StringLiteral
   FN: CallExpression | TaggedTemplateExpression
   FACTORY: string
-  NAME?: string
-  METHOD?: string
+  NAME?: StringLiteral
+  METHOD?: StringLiteral
   LOC?: ObjectExpression
 }) => CallExpression
 


### PR DESCRIPTION
## Summary
- Pass `t.stringLiteral(...)` for factory `sid` / `name` / `method` instead of `JSON.stringify(...)` when filling `@babel/template` placeholders.
- Babel 8 rejects string substitutions that are not valid identifiers or AST nodes, which broke factory wrapping (`withFactory`) for packages like `@farfetched/core` and `patronum`.
- Keeps the same generated output on Babel 7 while making the plugin compatible with Babel 8.

## Test plan
- [x] `yarn test --selectProjects babel`
- [x] New regression tests in `src/babel/__tests__/factory-template.test.js`
- [x] Built `effector/babel-plugin` transforms factories successfully under Babel 7.28 and Babel 8.0.1